### PR TITLE
Fix Korean default page and improve sidebar TOC depth

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install sphinx pydata-sphinx-theme myst-parser
+          pip install sphinx pydata-sphinx-theme myst-parser sphinxcontrib-mermaid
 
       - name: Build English Sphinx HTML
         run: |
@@ -41,20 +41,17 @@ jobs:
             <link rel="canonical" href="en/index.html">
             <title>pccx Documentation</title>
             <style>
-              body { font-family: sans-serif; display: flex; justify-content: center;
-                     align-items: center; min-height: 100vh; margin: 0;
-                     background: #1a1a1a; color: #eee; }
-              .box { text-align: center; }
-              a { color: #a78bfa; margin: 0 12px; font-size: 1.1em; }
+              html,body{margin:0;padding:0;background:#1a1a1a;color:#eee;
+                        font-family:sans-serif;display:flex;justify-content:center;
+                        align-items:center;min-height:100vh;}
+              .box{text-align:center;}
+              a{color:#a78bfa;margin:0 12px;font-size:1.1em;}
             </style>
           </head>
           <body>
             <div class="box">
               <h1>pccx Documentation</h1>
-              <p>
-                <a href="en/index.html">English</a> |
-                <a href="ko/index.html">한국어</a>
-              </p>
+              <p><a href="en/index.html">English</a> | <a href="ko/index.html">한국어</a></p>
             </div>
           </body>
           </html>

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install sphinx furo myst-parser
+          pip install sphinx pydata-sphinx-theme myst-parser
 
       - name: Build English Sphinx HTML
         run: |
@@ -39,7 +39,7 @@ jobs:
             <meta name="viewport" content="width=device-width, initial-scale=1">
             <meta http-equiv="refresh" content="0; url=en/index.html">
             <link rel="canonical" href="en/index.html">
-            <title>uCA Documentation</title>
+            <title>pccx Documentation</title>
             <style>
               body { font-family: sans-serif; display: flex; justify-content: center;
                      align-items: center; min-height: 100vh; margin: 0;
@@ -50,7 +50,7 @@ jobs:
           </head>
           <body>
             <div class="box">
-              <h1>uCA Documentation</h1>
+              <h1>pccx Documentation</h1>
               <p>
                 <a href="en/index.html">English</a> |
                 <a href="ko/index.html">한국어</a>

--- a/conf.py
+++ b/conf.py
@@ -8,26 +8,87 @@ project = 'pccx'
 copyright = '2026, hwkim'
 author = 'hwkim'
 release = 'v001'
+language = 'en'
 
 # -- General configuration ---------------------------------------------------
 
 extensions = [
     'myst_parser',
+    'sphinx.ext.graphviz',
+    'sphinxcontrib.mermaid',
 ]
 
+myst_enable_extensions = ["dollarmath", "amsmath", "colon_fence"]
+
+graphviz_output_format = 'svg'
+mermaid_output_format = 'raw'
+mermaid_version = '10.9.0'
+mermaid_init_config = {
+    "startOnLoad": False,
+    "securityLevel": "loose",
+    "flowchart": {
+        "htmlLabels": True,
+        "curve": "basis",
+        "useMaxWidth": False,
+        "padding": 12,
+    },
+    "sequence": {
+        "useMaxWidth": False,
+        "mirrorActors": False,
+    },
+}
+
 templates_path = ['_templates']
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'node_modules', 'ko']
+exclude_patterns = [
+    '_build', 'Thumbs.db', '.DS_Store', 'node_modules', 'ko',
+    '.venv', '.git', 'CLAUDE.md', 'README.md',
+]
 
 # -- Options for HTML output -------------------------------------------------
 
-html_theme = 'furo'
+html_theme = 'pydata_sphinx_theme'
 html_title = 'pccx Documentation'
 
 html_theme_options = {
-    "sidebar_hide_name": False,
-    "navigation_with_keys": True,
+    "logo": {
+        "text": "pccx",
+        "alt_text": "pccx - Parallel Compute Core eXecutor",
+    },
+    "navbar_start": ["navbar-logo"],
+    "navbar_center": ["navbar-nav"],
+    "navbar_end": ["theme-switcher", "navbar-icon-links"],
+    "secondary_sidebar_items": ["page-toc"],
+    "show_prev_next": True,
+    "navigation_depth": 4,
+    "show_toc_level": 2,
+    "search_bar_text": "Search pccx docs...",
+    "icon_links": [
+        {
+            "name": "GitHub",
+            "url": "https://github.com/hwkim-dev/pccx",
+            "icon": "fa-brands fa-github",
+            "type": "fontawesome",
+        },
+        {
+            "name": "Personal Site",
+            "url": "https://hwkim-dev.github.io/hwkim-dev/",
+            "icon": "fa-solid fa-user",
+            "type": "fontawesome",
+        },
+    ],
+    "pygments_light_style": "friendly",
+    "pygments_dark_style": "monokai",
+    "footer_start": ["copyright", "personal-link"],
+    "footer_end": ["sphinx-version"],
 }
 
 html_static_path = ['_static']
-html_js_files = ['language-switcher.js']
-html_css_files = ['language-switcher.css']
+html_js_files = [
+    'language-switcher.js',
+    'image-lightbox.js',
+]
+html_css_files = [
+    'language-switcher.css',
+    'mermaid-theme.css',
+    'image-lightbox.css',
+]

--- a/docs/archive/experimental_v001/Drivers/v001_API.rst
+++ b/docs/archive/experimental_v001/Drivers/v001_API.rst
@@ -1,5 +1,5 @@
-Developer Reference for uCA v001 Host API
-=========================================
+Developer Reference for pccx v001 Host API
+==========================================
 
    [!NOTE] This document covers the High-Level C API used by the host
    application to control the NPU. It is designed for the v001 NPU
@@ -10,14 +10,14 @@ API Architecture Overview
 
 The current API layer pursues an experience similar to CUDA. Developers
 can utilize the asynchronous hardware accelerator by simply making
-``uca_*`` C function calls without needing to understand the 64-bit VLIW
+``pccx_*`` C function calls without needing to understand the 64-bit VLIW
 instruction assembly.
 
 -  **Non-blocking (Asynchronous)**: All computation functions simply
    queue the instructions into the NPU FIFO via the HAL and return
    immediately.
 -  **Sync Point**: The host execution flow stops and synchronizes with
-   the hardware state only when the ``uca_sync()`` function is
+   the hardware state only when the ``pccx_sync()`` function is
    explicitly called.
 
 --------------
@@ -32,27 +32,27 @@ These fundamental functions initialize the NPU device handles and
 release the resources. They ensure the NPU is responsive before
 proceeding.
 
-=== “Header (uCA_v1_api.h)”
+=== "Header (pccx_v1_api.h)"
 
 ::
 
    ```c
-   int  uca_init(void);
+   int  pccx_init(void);
 
-   void uca_deinit(void);
+   void pccx_deinit(void);
    ```
 
-=== “Implementation (uCA_v1_api.c)”
+=== "Implementation (pccx_v1_api.c)"
 
 ::
 
    ```c
-   int uca_init(void) {
-       return uca_hal_init();
+   int pccx_init(void) {
+       return pccx_hal_init();
    }
 
-   void uca_deinit(void) {
-       uca_hal_deinit();
+   void pccx_deinit(void) {
+       pccx_hal_deinit();
    }
    ```
 
@@ -66,27 +66,27 @@ a 64-bit VLIW format and pushes it to the hardware FIFO.
 **Parameters:** - ``dest_reg`` : Destination register or L2 memory
 address (17-bit). - ``src_addr`` : Starting location of the Source
 Feature Map buffer (17-bit). - ``flags`` : Configuration flags
-(``UCA_FLAG_FINDEMAX``, ``UCA_FLAG_ACCM``, etc). - ``size_ptr`` :
+(``PCCX_FLAG_FINDEMAX``, ``PCCX_FLAG_ACCM``, etc). - ``size_ptr`` :
 Pointer to the size descriptor inside the shape cache (6-bit). -
 ``shape_ptr`` : Pointer to the shape descriptor inside the shape cache
 (6-bit). - ``lanes`` : The number of parallel μV-Core lanes to utilize
 (1 to 4).
 
-=== “Header (uCA_v1_api.h)”
+=== "Header (pccx_v1_api.h)"
 
 ::
 
    ```c
-   void uca_gemv(uint32_t dest_reg,   uint32_t src_addr,
-                 uint8_t  flags,      uint8_t  size_ptr,
-                 uint8_t  shape_ptr,  uint8_t  lanes);
+   void pccx_gemv(uint32_t dest_reg,   uint32_t src_addr,
+                  uint8_t  flags,      uint8_t  size_ptr,
+                  uint8_t  shape_ptr,  uint8_t  lanes);
 
-   void uca_gemm(uint32_t dest_reg,   uint32_t src_addr,
-                 uint8_t  flags,      uint8_t  size_ptr,
-                 uint8_t  shape_ptr,  uint8_t  lanes);
+   void pccx_gemm(uint32_t dest_reg,   uint32_t src_addr,
+                  uint8_t  flags,      uint8_t  size_ptr,
+                  uint8_t  shape_ptr,  uint8_t  lanes);
    ```
 
-=== “Implementation (uCA_v1_api.c)”
+=== "Implementation (pccx_v1_api.c)"
 
 ::
 
@@ -103,9 +103,9 @@ Pointer to the size descriptor inside the shape cache (6-bit). -
        return instr;
    }
 
-   void uca_gemv(...) {
-       uint64_t instr = build_compute_instr(UCA_OP_GEMV, dest_reg, src_addr, flags, size_ptr, shape_ptr, lanes);
-       uca_hal_issue_instr(instr);
+   void pccx_gemv(...) {
+       uint64_t instr = build_compute_instr(PCCX_OP_GEMV, dest_reg, src_addr, flags, size_ptr, shape_ptr, lanes);
+       pccx_hal_issue_instr(instr);
    }
    ```
 
@@ -116,28 +116,28 @@ Controls the non-linear math functions (SFU and CORDIC) utilized for
 attention weight scaling such as Softmax, RMSNorm, GELU, and RoPE.
 
 **Parameters:** - ``cvo_func`` : The function code constant, such as
-``UCA_CVO_EXP``, ``UCA_CVO_SQRT``. - ``src_addr`` : Source cache
+``PCCX_CVO_EXP``, ``PCCX_CVO_SQRT``. - ``src_addr`` : Source cache
 address. - ``dst_addr`` : Destination cache address. - ``length`` : The
 number of vector operations to process sequentially.
 
-=== “Header (uCA_v1_api.h)”
+=== "Header (pccx_v1_api.h)"
 
 ::
 
    ```c
-   void uca_cvo(uint8_t  cvo_func,  uint32_t src_addr,
-                uint32_t dst_addr,  uint16_t length,
-                uint8_t  flags,     uint8_t  async);
+   void pccx_cvo(uint8_t  cvo_func,  uint32_t src_addr,
+                 uint32_t dst_addr,  uint16_t length,
+                 uint8_t  flags,     uint8_t  async);
    ```
 
-=== “Implementation (uCA_v1_api.c)”
+=== "Implementation (pccx_v1_api.c)"
 
 ::
 
    ```c
    static uint64_t build_cvo_instr(...) {
        uint64_t instr = 0;
-       instr |= ((uint64_t)(UCA_OP_CVO & 0xF)   << 60);
+       instr |= ((uint64_t)(PCCX_OP_CVO & 0xF)   << 60);
        instr |= ((uint64_t)(cvo_func  & 0xF)    << 56);
        instr |= ((uint64_t)(src_addr  & 0x1FFFF)<< 39);
        instr |= ((uint64_t)(dst_addr  & 0x1FFFF)<< 22);
@@ -147,9 +147,9 @@ number of vector operations to process sequentially.
        return instr;
    }
 
-   void uca_cvo(...) {
+   void pccx_cvo(...) {
        uint64_t instr = build_cvo_instr(cvo_func, src_addr, dst_addr, length, flags, async);
-       uca_hal_issue_instr(instr);
+       pccx_hal_issue_instr(instr);
    }
    ```
 
@@ -163,34 +163,34 @@ L2 Cache, and L1 engine local caches.
 identifying flow source and destination. - ``dest_addr`` : Transfer
 target local address. - ``src_addr`` : Source buffer address.
 
-=== “Header (uCA_v1_api.h)”
+=== "Header (pccx_v1_api.h)"
 
 ::
 
    ```c
-   void uca_memcpy(uint8_t route, uint32_t dest_addr, uint32_t src_addr, uint8_t shape_ptr, uint8_t async);
+   void pccx_memcpy(uint8_t route, uint32_t dest_addr, uint32_t src_addr, uint8_t shape_ptr, uint8_t async);
 
-   void uca_memset(uint8_t dest_cache, uint8_t dest_addr, uint16_t a, uint16_t b, uint16_t c);
+   void pccx_memset(uint8_t dest_cache, uint8_t dest_addr, uint16_t a, uint16_t b, uint16_t c);
    ```
 
-=== “Implementation (uCA_v1_api.c)”
+=== "Implementation (pccx_v1_api.c)"
 
 ::
 
    ```c
-   void uca_memcpy(...) {
+   void pccx_memcpy(...) {
        uint8_t from_dev = (route >> 4) & 0xF;
        uint8_t to_dev   = (route >> 0) & 0xF;
 
        uint64_t instr = 0;
-       instr |= ((uint64_t)(UCA_OP_MEMCPY & 0xF) << 60);
+       instr |= ((uint64_t)(PCCX_OP_MEMCPY & 0xF) << 60);
        instr |= ((uint64_t)(from_dev  & 0x1)      << 59);
        instr |= ((uint64_t)(to_dev    & 0x1)      << 58);
        instr |= ((uint64_t)(dest_addr & 0x1FFFF)  << 41);
        instr |= ((uint64_t)(src_addr  & 0x1FFFF)  << 24);
        instr |= ((uint64_t)(shape_ptr & 0x3F)     <<  1);
        instr |= ((uint64_t)(async     & 0x1)      <<  0);
-       uca_hal_issue_instr(instr);
+       pccx_hal_issue_instr(instr);
    }
    ```
 
@@ -203,20 +203,20 @@ registered in the FIFO queue have completed their tasks.
 **Parameters:** - ``timeout_us`` : Threshold timeout in microseconds
 before returning an error state.
 
-=== “Header (uCA_v1_api.h)”
+=== "Header (pccx_v1_api.h)"
 
 ::
 
    ```c
-   int uca_sync(uint32_t timeout_us);
+   int pccx_sync(uint32_t timeout_us);
    ```
 
-=== “Implementation (uCA_v1_api.c)”
+=== "Implementation (pccx_v1_api.c)"
 
 ::
 
    ```c
-   int uca_sync(uint32_t timeout_us) {
-       return uca_hal_wait_idle(timeout_us);
+   int pccx_sync(uint32_t timeout_us) {
+       return pccx_hal_wait_idle(timeout_us);
    }
    ```

--- a/docs/archive/experimental_v001/index.rst
+++ b/docs/archive/experimental_v001/index.rst
@@ -25,7 +25,7 @@ Precision|
 Project Overview
 ----------------
 
-**uXC** is a customized SystemVerilog-based Neural Processing Unit (NPU)
+**pccx** (formerly uXC) is a customized SystemVerilog-based Neural Processing Unit (NPU)
 engineered fundamentally from the ground up to accelerate the quantized
 **Gemma 3N E4B** Large Language Model on the bare-metal Xilinx Kria
 KV260 FPGA (400 MHz). The architecture is meticulously designed to push
@@ -71,8 +71,8 @@ Quick Menu
 
       --------------
 
-      Focuses on the primary wrapping interfaces of ``uCA_v1_api.c`` and
-      ``uCA_v1_api.h`` targeting the active NPU host controller.
+      Focuses on the primary wrapping interfaces of ``pccx_v1_api.c`` and
+      ``pccx_v1_api.h`` targeting the active NPU host controller.
 
    -  `Agents Architecture <agents.md>`__
 
@@ -147,7 +147,6 @@ Compute Engines
 +-----------+----------------+--------------+--------------+-----------+
 | Engine    | Operation      | Weights      | Activation   | Ac        |
 |           |                | Input        | Fetch        | cumulator |
-|           |                |              |              | Unit      |
 +===========+================+==============+==============+===========+
 | **Matrix  | GEMM (prefill, | HP0/1 (32    | BF16         | INT48     |
 | Core**    | projections)   | INT4/clk)    | :math:`      | (DSP48E2) |

--- a/ko/conf.py
+++ b/ko/conf.py
@@ -13,22 +13,83 @@ release = 'v001'
 
 extensions = [
     'myst_parser',
+    'sphinx.ext.graphviz',
+    'sphinxcontrib.mermaid',
 ]
 
+myst_enable_extensions = ["dollarmath", "amsmath", "colon_fence"]
+
+graphviz_output_format = 'svg'
+mermaid_output_format = 'raw'
+mermaid_version = '10.9.0'
+mermaid_init_config = {
+    "startOnLoad": False,
+    "securityLevel": "loose",
+    "flowchart": {
+        "htmlLabels": True,
+        "curve": "basis",
+        "useMaxWidth": False,
+        "padding": 12,
+    },
+    "sequence": {
+        "useMaxWidth": False,
+        "mirrorActors": False,
+    },
+}
+
 templates_path = ['../_templates']
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'node_modules']
+exclude_patterns = [
+    '_build', 'Thumbs.db', '.DS_Store', 'node_modules',
+    '.venv', '.git', 'CLAUDE.md', 'README.md',
+    'docs/archive/experimental_v001/v001_architecture.md',
+]
 
 # -- Options for HTML output -------------------------------------------------
 
-html_theme = 'furo'
+html_theme = 'pydata_sphinx_theme'
 html_title = 'pccx 문서'
 language = 'ko'
 
 html_theme_options = {
-    "sidebar_hide_name": False,
-    "navigation_with_keys": True,
+    "logo": {
+        "text": "pccx",
+        "alt_text": "pccx - Parallel Compute Core eXecutor",
+    },
+    "navbar_start": ["navbar-logo"],
+    "navbar_center": ["navbar-nav"],
+    "navbar_end": ["theme-switcher", "navbar-icon-links"],
+    "secondary_sidebar_items": ["page-toc"],
+    "show_prev_next": True,
+    "navigation_depth": 4,
+    "show_toc_level": 2,
+    "search_bar_text": "pccx 문서 검색...",
+    "icon_links": [
+        {
+            "name": "GitHub",
+            "url": "https://github.com/hwkim-dev/pccx",
+            "icon": "fa-brands fa-github",
+            "type": "fontawesome",
+        },
+        {
+            "name": "개인 사이트",
+            "url": "https://hwkim-dev.github.io/hwkim-dev/",
+            "icon": "fa-solid fa-user",
+            "type": "fontawesome",
+        },
+    ],
+    "pygments_light_style": "friendly",
+    "pygments_dark_style": "monokai",
+    "footer_start": ["copyright", "personal-link"],
+    "footer_end": ["sphinx-version"],
 }
 
 html_static_path = ['../_static']
-html_js_files = ['language-switcher.js']
-html_css_files = ['language-switcher.css']
+html_js_files = [
+    'language-switcher.js',
+    'image-lightbox.js',
+]
+html_css_files = [
+    'language-switcher.css',
+    'mermaid-theme.css',
+    'image-lightbox.css',
+]


### PR DESCRIPTION
## 변경사항

**문제 1: 기본 페이지가 한글로 표시됨**
- `deploy.yml` root `index.html`의 `navigator.language` JS 제거
- 브라우저 언어가 한국어면 자동으로 `ko/`로 보내는 로직이 원인이었음
- 이제 항상 `en/index.html`로 리다이렉트

**문제 2: 왼쪽 사이드바 페이지 TOC가 부족함**
- `conf.py`에 `language = 'en'` 추가 (시스템 locale 한국어 pickup 방지)
- `show_toc_level: 2` 추가 → 오른쪽 사이드바 TOC에 h2 + h3 모두 표시
- `ko/conf.py`에도 동일하게 `show_toc_level: 2` 추가