### PR TITLE
Fix Korean default page and improve sidebar TOC depth

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,22 +33,27 @@ jobs:
           touch _build/html/.nojekyll
           cat > _build/html/index.html << 'EOF'
           <!DOCTYPE html>
-          <html>
+          <html lang="en">
           <head>
             <meta charset="utf-8">
-            <title>pccx Documentation</title>
-            <link rel="canonical" href="en/index.html">
-            <script>
-              (function () {
-                var lang = (navigator.language || 'en').toLowerCase();
-                var target = lang.indexOf('ko') === 0 ? 'ko/index.html' : 'en/index.html';
-                location.replace(target);
-              })();
-            </script>
+            <meta name="viewport" content="width=device-width, initial-scale=1">
             <meta http-equiv="refresh" content="0; url=en/index.html">
-            <style>html,body{margin:0;padding:0;background:#1a1a1a;}</style>
+            <link rel="canonical" href="en/index.html">
+            <title>pccx Documentation</title>
+            <style>
+              html,body{margin:0;padding:0;background:#1a1a1a;color:#eee;
+                        font-family:sans-serif;display:flex;justify-content:center;
+                        align-items:center;min-height:100vh;}
+              .box{text-align:center;}
+              a{color:#a78bfa;margin:0 12px;font-size:1.1em;}
+            </style>
           </head>
-          <body></body>
+          <body>
+            <div class="box">
+              <h1>pccx Documentation</h1>
+              <p><a href="en/index.html">English</a> | <a href="ko/index.html">한국어</a></p>
+            </div>
+          </body>
           </html>
           EOF
 

--- a/conf.py
+++ b/conf.py
@@ -8,6 +8,7 @@ project = 'pccx'
 copyright = '2026, hwkim'
 author = 'hwkim'
 release = 'v001'
+language = 'en'
 
 # -- General configuration ---------------------------------------------------
 
@@ -22,9 +23,6 @@ myst_enable_extensions = ["dollarmath", "amsmath", "colon_fence"]
 graphviz_output_format = 'svg'
 mermaid_output_format = 'raw'
 mermaid_version = '10.9.0'
-# sphinxcontrib-mermaid already observes <html data-theme> and re-renders
-# on toggle; we only customize layout so wide flowcharts scroll instead of
-# shrinking text below legibility.
 mermaid_init_config = {
     "startOnLoad": False,
     "securityLevel": "loose",
@@ -62,6 +60,7 @@ html_theme_options = {
     "secondary_sidebar_items": ["page-toc"],
     "show_prev_next": True,
     "navigation_depth": 4,
+    "show_toc_level": 2,
     "search_bar_text": "Search pccx docs...",
     "icon_links": [
         {

--- a/ko/conf.py
+++ b/ko/conf.py
@@ -61,6 +61,7 @@ html_theme_options = {
     "secondary_sidebar_items": ["page-toc"],
     "show_prev_next": True,
     "navigation_depth": 4,
+    "show_toc_level": 2,
     "search_bar_text": "pccx 문서 검색...",
     "icon_links": [
         {


### PR DESCRIPTION
## 변경사항\n\n**문제 1: 기본 페이지가 한글로 표시됨**\n- `deploy.yml` root `index.html`의 `navigator.language` JS 제거\n- 브라우저 언어가 한국어면 자동으로 `ko/`로 보내는 로직이 원인이었음\n- 이제 항상 `en/index.html`로 리다이렉트\n\n**문제 2: 사이드바 페이지 TOC가 부족함**\n- `conf.py`에 `language = 'en'` 추가 (시스템 locale 한국어 pickup 방지)\n- `show_toc_level: 2` 추가 → 오른쪽 사이드바 TOC에 h2 + h3 모두 표시\n- `ko/conf.py`에도 동일하게 `show_toc_level: 2` 추가