### PR TITLE
Fix CI: install all packages from requirements.txt

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,10 +14,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install dependencies
+      - name: Install system packages
+        run: sudo apt-get install -y graphviz
+
+      - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install sphinx pydata-sphinx-theme myst-parser sphinxcontrib-mermaid
+          pip install -r requirements.txt
 
       - name: Clone v002 RTL repository
         run: |


### PR DESCRIPTION
## 원인

`deploy.yml`이 수동으로 패키지를 나열하고 있어서 PR #9에서 추가된 새 extensions들이 설치되지 않음.

```
Extension error!
Could not import extension myst_nb (exception: No module named 'myst_nb')
```

## 변경사항

- `pip install sphinx pydata-sphinx-theme myst-parser sphinxcontrib-mermaid` 제거
- `pip install -r requirements.txt` 로 교체 → `conf_common.py`에 선언된 모든 extension이 자동으로 설치됨
- `sudo apt-get install -y graphviz` 추가 (`sphinx.ext.graphviz`가 시스템 `dot` 바이너리 필요)