### PR TITLE
ci: add lightweight repository validation

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,63 @@
+name: repo-validate
+
+# Lightweight always-run gate. Fast, decisive, no external installs.
+# Designed to be a stable required-status-check candidate for the main
+# branch: every push and every pull request triggers it, with no paths
+# filter. The heavy doc workflows (Sphinx Pages, EN/KO doc set, isa-pdf,
+# Docs lint) all have paths filters and are therefore unsuitable for
+# required-check enforcement on their own; this workflow fills that gap.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  repo-validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Forbidden basename scan
+        run: |
+          set -e
+          bad=$(git ls-files | grep -iE '(^|/)(CLAUDE|GEMINI|AGENTS|JULES_REVIEW)\.md$|^TODO\.md$|^\.private-ai/|^\.github/workflows/private-ci\.yml$|^\.github/workflows/gemini-.*\.yml$|_Tasks_for_Claude' || true)
+          if [ -n "$bad" ]; then
+            echo "::error::Forbidden basenames present in tracked tree:"
+            echo "$bad"
+            exit 1
+          fi
+
+      - name: Stale owner URL scan
+        run: |
+          set -e
+          # pccx and its siblings transferred to the pccxai org on 2026-04-30.
+          # The personal references @hkimw and hkimw.github.io/hkimw/ are
+          # intentionally preserved (author handle and personal Pages).
+          bad=$(git grep -nE \
+              'hwkim-dev|hkimw\.github\.io/pccx|hwkim-dev\.github\.io/pccx|github\.com/hwkim-dev/pccx|github\.com/hkimw/pccx([^-a-zA-Z]|$)|github\.com/hkimw/pccx-lab|github\.com/hkimw/pccx-FPGA-NPU-LLM-kv260' \
+              -- ':!.github/workflows/validate.yml' || true)
+          if [ -n "$bad" ]; then
+            echo "::error::Stale owner URLs found (pccx ecosystem moved to pccxai/*):"
+            echo "$bad"
+            exit 1
+          fi
+
+      - name: YAML syntax (workflow files)
+        run: |
+          set -e
+          for f in .github/workflows/*.yml .github/workflows/*.yaml; do
+            [ -f "$f" ] || continue
+            python3 -c "import sys, yaml; yaml.safe_load(open('$f'))" \
+              || { echo "::error::YAML parse error in $f"; exit 1; }
+          done

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -3,9 +3,8 @@ name: repo-validate
 # Lightweight always-run gate. Fast, decisive, no external installs.
 # Designed to be a stable required-status-check candidate for the main
 # branch: every push and every pull request triggers it, with no paths
-# filter. The heavy doc workflows (Sphinx Pages, EN/KO doc set, isa-pdf,
-# Docs lint) all have paths filters and are therefore unsuitable for
-# required-check enforcement on their own; this workflow fills that gap.
+# filter. The heavy doc workflows have paths filters and are therefore
+# unsuitable as required checks on their own; this fills that gap.
 
 on:
   push:
@@ -31,25 +30,48 @@ jobs:
       - name: Forbidden basename scan
         run: |
           set -e
-          bad=$(git ls-files | grep -iE '(^|/)(CLAUDE|GEMINI|AGENTS|JULES_REVIEW)\.md$|^TODO\.md$|^\.private-ai/|^\.github/workflows/private-ci\.yml$|^\.github/workflows/gemini-.*\.yml$|_Tasks_for_Claude' || true)
+          bad=""
+          for name in CLAUDE.md GEMINI.md AGENTS.md JULES_REVIEW.md TODO.md; do
+            hits=$(git ls-files | grep -E "(^|/)${name}\$" || true)
+            if [ -n "$hits" ]; then bad="${bad}${hits}"$'\n'; fi
+          done
+          for prefix in '.private-ai/' '.github/workflows/private-ci.yml' '.github/workflows/gemini-'; do
+            hits=$(git ls-files | grep -F "$prefix" || true)
+            if [ -n "$hits" ]; then bad="${bad}${hits}"$'\n'; fi
+          done
+          tasks=$(git ls-files | grep -F "_Tasks_for_Claude" || true)
+          if [ -n "$tasks" ]; then bad="${bad}${tasks}"$'\n'; fi
           if [ -n "$bad" ]; then
             echo "::error::Forbidden basenames present in tracked tree:"
-            echo "$bad"
+            printf '%s' "$bad"
             exit 1
           fi
 
       - name: Stale owner URL scan
         run: |
           set -e
-          # pccx and its siblings transferred to the pccxai org on 2026-04-30.
-          # The personal references @hkimw and hkimw.github.io/hkimw/ are
-          # intentionally preserved (author handle and personal Pages).
-          bad=$(git grep -nE \
-              'hwkim-dev|hkimw\.github\.io/pccx|hwkim-dev\.github\.io/pccx|github\.com/hwkim-dev/pccx|github\.com/hkimw/pccx([^-a-zA-Z]|$)|github\.com/hkimw/pccx-lab|github\.com/hkimw/pccx-FPGA-NPU-LLM-kv260' \
-              -- ':!.github/workflows/validate.yml' || true)
+          # pccx and siblings transferred to the pccxai org on 2026-04-30.
+          # The personal handle @hkimw and the personal Pages site
+          # hkimw.github.io/hkimw/ are intentionally preserved.
+          bad=""
+          for pattern in \
+            'hwkim-dev' \
+            'hkimw.github.io/pccx' \
+            'hwkim-dev.github.io/pccx' \
+            'github.com/hwkim-dev/pccx' \
+            'github.com/hkimw/pccx-lab' \
+            'github.com/hkimw/pccx-FPGA-NPU-LLM-kv260'
+          do
+            hits=$(git grep -nF -- "$pattern" -- ':!.github/workflows/validate.yml' || true)
+            if [ -n "$hits" ]; then bad="${bad}${hits}"$'\n'; fi
+          done
+          # Bare github.com/hkimw/pccx (not followed by -lab or -FPGA-...).
+          # Use grep -P to avoid hyphen-leading character classes.
+          hits=$(git grep -nP 'github\.com/hkimw/pccx(?![A-Za-z0-9-])' -- ':!.github/workflows/validate.yml' || true)
+          if [ -n "$hits" ]; then bad="${bad}${hits}"$'\n'; fi
           if [ -n "$bad" ]; then
-            echo "::error::Stale owner URLs found (pccx ecosystem moved to pccxai/*):"
-            echo "$bad"
+            echo "::error::Stale owner URLs found:"
+            printf '%s' "$bad"
             exit 1
           fi
 
@@ -58,6 +80,6 @@ jobs:
           set -e
           for f in .github/workflows/*.yml .github/workflows/*.yaml; do
             [ -f "$f" ] || continue
-            python3 -c "import sys, yaml; yaml.safe_load(open('$f'))" \
+            python3 -c "import sys, yaml; yaml.safe_load(open(sys.argv[1]))" "$f" \
               || { echo "::error::YAML parse error in $f"; exit 1; }
           done


### PR DESCRIPTION
## Summary

Add `.github/workflows/validate.yml` -- a fast always-run gate designed as a stable required-status-check candidate for `main`. The existing doc workflows (Sphinx Pages, EN/KO doc set, isa-pdf, Docs lint) all have paths filters and so cannot back a required check on their own; this fills that gap.

## Job: `repo-validate`

Runs on every push to main and every pull request, no paths filter, ubuntu-latest, 5-minute timeout.

Checks:

1. **Forbidden basename scan** -- rejects accidental commits of CLAUDE.md / GEMINI.md / AGENTS.md / JULES_REVIEW.md / TODO.md / .private-ai/ / private-ci.yml / `gemini-*.yml` / _Tasks_for_Claude_* in tracked tree.
2. **Stale owner URL scan** -- rejects post-transfer regressions (`hwkim-dev`, `hwkim-dev.github.io/pccx`, `hkimw.github.io/pccx`, `github.com/hkimw/pccx*`). The personal handle `@hkimw` and `hkimw.github.io/hkimw/` (personal Pages) are intentionally allowed.
3. **YAML syntax** -- parses every workflow file via `python3 yaml.safe_load`.

## Verification

- Local dry-run of all three scans: 0 hits each.
- YAML syntax: OK.
- Private staging CI: [run 25164107544](https://github.com/pccxai/pccx-staging/actions/runs/25164107544) -- success.

## Out of scope

- No replacement for Sphinx full builds. Heavy doc workflows continue with their existing paths filters.
- No external installs (only stock ubuntu-latest tools used).