### PR TITLE
ci: opt JavaScript actions into Node.js 24

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,9 @@ env:
   ACTIVE_VERSION: v002
   RTL_REPO_URL: https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260
   RTL_REPO_REF: main
+  # Opt JavaScript actions into the Node.js 24 runtime ahead of the
+  # 2026-06-02 forced cutover.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/en-ko-sync.yml
+++ b/.github/workflows/en-ko-sync.yml
@@ -12,6 +12,11 @@ on:
       - "docs/**"
       - "ko/docs/**"
 
+# Opt JavaScript actions into the Node.js 24 runtime ahead of the
+# 2026-06-02 forced cutover.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   file-set-symmetry:
     name: EN / KO file set must match

--- a/.github/workflows/isa-pdf.yml
+++ b/.github/workflows/isa-pdf.yml
@@ -26,6 +26,11 @@ on:
       - ".github/workflows/isa-pdf.yml"
   workflow_dispatch:
 
+# Opt JavaScript actions into the Node.js 24 runtime ahead of the
+# 2026-06-02 forced cutover.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,6 +35,9 @@ env:
   ACTIVE_VERSION: v002
   RTL_REPO_URL: https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260
   RTL_REPO_REF: main
+  # Opt JavaScript actions into the Node.js 24 runtime ahead of the
+  # 2026-06-02 forced cutover.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   strict-build:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -19,6 +19,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Opt JavaScript actions into the Node.js 24 runtime ahead of the
+# 2026-06-02 forced cutover.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   repo-validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env to all five workflow files so JavaScript actions (`actions/checkout`, `actions/setup-python`, `actions/upload-artifact`, `peaceiris/actions-gh-pages`) use the Node.js 24 runtime ahead of the 2026-06-02 forced cutover.

No version bumps; no behavioural change beyond the runtime.

## Diff

- `deploy.yml`: +3 / -0 (var added to existing `env:` block alongside `RTL_REPO_URL` etc.)
- `lint.yml`: +3 / -0 (same pattern as deploy.yml)
- `en-ko-sync.yml`: +5 / -0 (new top-level `env:` block)
- `isa-pdf.yml`: +5 / -0 (new top-level `env:` block)
- `validate.yml`: +5 / -0 (new top-level `env:` block)

Total: 5 files, +21 / -0.

## Verification

- YAML syntax: 5/5 OK.
- Private staging CI: [run 25178880793](https://github.com/pccxai/pccx-staging/actions/runs/25178880793) -- success (`docs-strict` job, which runs `make lint` / `make strict` / `make linkcheck` against candidate/main).
- The Stage 3 required check `repo-validate` runs on this PR; passing it is the natural validation that the env var did not break the workflow grammar.