### PR TITLE
chore: update citation metadata

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,10 +14,7 @@ url: "https://pccxai.github.io/pccx/"
 authors:
   - family-names: Kim
     given-names: Hyunwoo
-    # TODO(hkimw): set orcid once registered
-    # orcid: "https://orcid.org/0000-0000-0000-0000"
-    # TODO(hkimw): fill in affiliation
-    # affiliation: ""
+    affiliation: "Independent researcher"
 keywords:
   - FPGA
   - LLM inference


### PR DESCRIPTION
Resolves the `TODO(hkimw)` placeholders left in `CITATION.cff` after the
organization transfer to `pccxai`.

## Changes

- Drop the `# TODO(hkimw)` comment block under `authors`.
- Add `affiliation: "Independent researcher"`.
- ORCID intentionally omitted — author has not registered one yet, so
  the `orcid:` field is left out entirely rather than carrying a
  placeholder.
- No other field touched (title, abstract, keywords, references,
  repository-code, url all unchanged).

## Validation

- `python3 -c "import yaml; yaml.safe_load(open('CITATION.cff'))"` — parses cleanly.
- No vendor / brand tokens added (`NVIDIA`, `Intel`).
- No URL change; `repository-code` and `url` already point at `pccxai`.

## Out of scope

- Release publishing / tag creation.
- Ruleset or required-checks changes.
- README / docs prose edits.