### PR TITLE
docs: add v0.1.0-alpha release draft

### DIFF
--- a/docs/releases/v0.1.0-alpha.md
+++ b/docs/releases/v0.1.0-alpha.md
@@ -1,3 +1,7 @@
+---
+orphan: true
+---
+
 # pccx v0.1.0-alpha — release draft
 
 > **Draft only — do not publish.** No tag is created, no GitHub release

--- a/docs/releases/v0.1.0-alpha.md
+++ b/docs/releases/v0.1.0-alpha.md
@@ -1,0 +1,82 @@
+# pccx v0.1.0-alpha — release draft
+
+> **Draft only — do not publish.** No tag is created, no GitHub release
+> is published. This file is a planning document for human review and
+> will be turned into the actual release notes when the v0.1.0-alpha
+> tag is eventually pushed in a separately approved cycle.
+
+- **Target repo**: `pccxai/pccx`
+- **Target base SHA**: `f6247e3` (current `main` HEAD as of 2026-05-01,
+  immediately after the citation-metadata cleanup merge)
+- **Title (proposed)**: `pccx v0.1.0-alpha — first public architecture snapshot`
+- **Tag (proposed, NOT created)**: `v0.1.0-alpha`
+- **Pre-release**: yes
+
+## Highlights
+
+- First snapshot of the canonical pccx architecture, ISA, and
+  documentation site under the `pccxai` organization.
+- Bilingual (EN + KO) Sphinx site with `numfig`, MyST and MyST-NB,
+  multiversion publishing, and Furo dark/light theme; live at
+  `https://pccxai.github.io/pccx/`.
+- ISA package (`isa_pkg.sv`) cross-referenced from the docs through
+  `literalinclude` against the `codes/v002/` clone produced at build
+  time from the sibling RTL repository.
+- ISA preprint PDF build (`isa-pdf.yml`, `xelatex`) producing the
+  tracked `_static/downloads/pccx-isa-v002.pdf`.
+- Repo-validation CI (`repo-validate`) covering URL hygiene,
+  brand-name guard, Pages build sanity, and required-checks
+  enforcement on `main`.
+- Three-stage GitHub ruleset on `main` (force-push and branch-deletion
+  block, PR-required, required status checks). Direct push to `main`
+  is blocked.
+- Citation metadata in tree: `CITATION.cff` (with author and
+  `Independent researcher` affiliation), `CHANGELOG.md`, `RELEASING.md`.
+
+## Known limitations
+
+- W4A8 throughput numbers in the docs are framed as planning targets,
+  not measured silicon results.
+- v002 RTL is referenced from the `pccxai/pccx-FPGA-NPU-LLM-kv260`
+  sibling repo at build time; this repo does not contain a bitstream
+  or place-and-route closure.
+- The KV cache memory model section is documentation-level; the
+  on-chip layout is described, not benchmarked.
+- v003 architecture is roadmap only; no scaffolding has landed.
+- Localization beyond EN and KO is tracked under
+  `M2 — v0.3 Community Localization` and is not part of this snapshot.
+
+## Validation status
+
+- `make strict` builds clean (zero warnings) on EN and KO sources.
+- `make linkcheck` clean on the weekly cron.
+- `repo-validate` required check green on `main`.
+- ISA PDF build green on `main`.
+- Sphinx Pages deploy green; `https://pccxai.github.io/pccx/` returns
+  HTTP 200.
+- No standalone-vendor brand-token leaks in tracked sources
+  (word-boundary scan).
+
+## Citation
+
+Cite using the in-repo `CITATION.cff` (author: Hyunwoo Kim,
+Independent researcher; ORCID intentionally omitted until registered).
+This release does not mint a Zenodo DOI yet; that will follow once the
+v0.1.0-alpha tag is actually pushed in a later, separately approved
+cycle.
+
+## Not included in this release
+
+- Tag push or GitHub Release publication.
+- Zenodo DOI minting.
+- arXiv submission of the ISA preprint.
+- Localization launch (Spanish, Japanese, Chinese) — tracked as
+  `lang:*` labels for v0.3.
+
+## Next milestones
+
+- `v0.2.0` (subtitle: "Docs and KV cache"): deepen the KV cache
+  memory-model section, add measured-vs-target numbers, expand RTL
+  cross-references.
+- `v0.3.0` (subtitle: "Community localization"): open the
+  `lang:es / ja / zh` workflow, add a translation contribution guide.

--- a/ko/docs/releases/v0.1.0-alpha.md
+++ b/ko/docs/releases/v0.1.0-alpha.md
@@ -1,0 +1,79 @@
+---
+orphan: true
+---
+
+# pccx v0.1.0-alpha — 릴리스 초안
+
+> **초안일 뿐입니다 — 배포하지 마세요.** 태그를 만들지 않으며,
+> GitHub Release도 발행하지 않습니다. 이 파일은 사람 검토를 위한
+> 계획 문서이며, v0.1.0-alpha 태그가 별도 승인 사이클에서 실제로
+> 푸시되는 시점에 릴리스 노트의 본문으로 사용됩니다.
+
+- **대상 저장소**: `pccxai/pccx`
+- **기준 SHA**: `f6247e3` (2026-05-01 기준 `main` HEAD,
+  citation-metadata 정리 머지 직후)
+- **제안 제목**: `pccx v0.1.0-alpha — 첫 공개 아키텍처 스냅샷`
+- **제안 태그 (생성하지 않음)**: `v0.1.0-alpha`
+- **사전 릴리스(pre-release)**: 예
+
+## 주요 변경 사항
+
+- `pccxai` 조직 산하에서 첫 공개되는 pccx 아키텍처, ISA, 문서
+  사이트 스냅샷.
+- EN + KO 이중 언어 Sphinx 사이트 (`numfig`, MyST + MyST-NB,
+  multiversion 게시, Furo 다크/라이트 테마). 게시 위치:
+  `https://pccxai.github.io/pccx/`.
+- ISA 패키지(`isa_pkg.sv`)를 `literalinclude`로 참조하도록 빌드 중
+  형제 RTL 저장소를 `codes/v002/`로 클론하는 cross-repo 빌드 파이프라인
+  연결.
+- ISA preprint PDF 빌드(`isa-pdf.yml`, `xelatex`)로
+  `_static/downloads/pccx-isa-v002.pdf` 산출.
+- repo-validation CI(`repo-validate`): URL 위생, 브랜드 단어 가드,
+  Pages 빌드 sanity, `main`의 required check 강제.
+- `main`에 3단계 ruleset 활성: force-push 및 브랜치 삭제 차단,
+  PR 강제, required status check. `main` 직접 push 차단됨.
+- in-tree citation 메타데이터: `CITATION.cff`(저자 +
+  `Independent researcher` affiliation 반영), `CHANGELOG.md`,
+  `RELEASING.md`.
+
+## 알려진 한계
+
+- 문서의 W4A8 처리량 수치는 측정값이 아닌 계획 목표치입니다.
+- v002 RTL은 빌드 시 `pccxai/pccx-FPGA-NPU-LLM-kv260` 형제 저장소에서
+  참조하며, 본 저장소에는 비트스트림이나 P&R 클로저 산출물이 없습니다.
+- KV cache 메모리 모델 섹션은 문서 수준 설명이며, 온칩 레이아웃은
+  벤치마크되어 있지 않습니다.
+- v003 아키텍처는 로드맵 단계로 스캐폴드만 예정되어 있습니다.
+- EN/KO 외 로컬라이제이션은 `M2 — v0.3 Community Localization`에서
+  추적되며 본 스냅샷에는 포함되지 않습니다.
+
+## 검증 상태
+
+- `make strict`: EN/KO 소스에서 경고 없이 빌드 성공.
+- `make linkcheck`: 주간 cron에서 통과.
+- `repo-validate` required check: `main` 녹색.
+- ISA PDF 빌드: `main` 녹색.
+- Sphinx Pages 배포: 녹색. `https://pccxai.github.io/pccx/` HTTP 200 응답.
+- 추적 소스에서 단일 벤더 브랜드 토큰 누출 없음 (워드 바운더리 스캔).
+
+## 인용
+
+저장소의 `CITATION.cff`를 사용해 인용해 주세요 (저자: Hyunwoo Kim,
+Independent researcher; ORCID는 등록 전이라 의도적으로 비워둠).
+본 릴리스에서는 Zenodo DOI를 발행하지 않으며, v0.1.0-alpha 태그가
+별도 승인 사이클에서 실제로 푸시될 때 발행 예정입니다.
+
+## 본 릴리스에 포함되지 않는 것
+
+- 태그 푸시 또는 GitHub Release 발행.
+- Zenodo DOI 발행.
+- ISA preprint의 arXiv 제출.
+- 로컬라이제이션 런칭 (스페인어, 일본어, 중국어). v0.3에서 `lang:*`
+  레이블로 추적.
+
+## 다음 마일스톤
+
+- `v0.2.0` (부제: "Docs and KV cache"): KV cache 메모리 모델 섹션 심화,
+  측정값 대비 목표치 비교 추가, RTL cross-reference 확장.
+- `v0.3.0` (부제: "Community localization"): `lang:es / ja / zh`
+  워크플로 개시, 번역 기여 가이드 추가.


### PR DESCRIPTION
Adds `docs/releases/v0.1.0-alpha.md` as an in-tree draft for the
upcoming v0.1.0-alpha release notes. The file is explicitly marked
**Draft only — do not publish** at the top, so it will not be turned
into a GitHub Release until a separately approved cycle.

## Why land it now

- Locks the release scope (highlights, known limitations, next
  milestones) against the current `main` SHA so reviewers comment on a
  stable text rather than a moving target.
- Lets the eventual release-publish step copy this file verbatim into
  the GitHub Release body — no last-minute prose authoring.
- Becomes the artefact contributors can link to from issues / PRs /
  discussions during the run-up to the tag.

## What this PR is *not*

- It does **not** create a tag.
- It does **not** publish a GitHub Release.
- It does **not** mint a Zenodo DOI.
- It does **not** modify rulesets, required checks, or workflows.

## Validation

- Markdown only; no code, no CI workflow, no settings.
- No vendor / brand tokens added (`NVIDIA`, standalone-vendor names).
- Base SHA pinned to current `main` HEAD at the top of the file.