### PR TITLE
docs: improve README first impression

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,24 @@
 
 ---
 
+## Project status
+
+**Public alpha** — first tagged release `v0.1.0-alpha` is in draft. Core
+architecture and ISA are stable; verification, KV260 bring-up, and
+documentation polish are in progress. Expect rough edges; feedback and
+issues are welcome.
+
+| Entry point | Link |
+| --- | --- |
+| Documentation | <https://pccxai.github.io/pccx/> |
+| Releases | <https://github.com/pccxai/pccx/releases> |
+| Roadmap (project board) | <https://github.com/orgs/pccxai/projects/1> |
+| Contributing | [CONTRIBUTING.md](CONTRIBUTING.md) |
+| Discussions | <https://github.com/pccxai/pccx/discussions> |
+| Good first issues | <https://github.com/pccxai/pccx/labels/good%20first%20issue> |
+
+---
+
 ## What is pccx?
 
 pccx is a hardware-software co-design framework that accelerates **autoregressive decoding** of Transformer-based LLMs on resource-constrained edge devices. The primary target is the **Xilinx Kria KV260** SOM.


### PR DESCRIPTION
## Summary
- Add a **Project status** section near the top of the README so first-time visitors land on the alpha-status framing and the canonical entry points without scrolling.
- Single table with: docs site, releases, roadmap project, contributing, discussions, good first issues.
- Tone matches existing README — no new technical claims, no rewrite of body content.

## Test plan
- [ ] Render renders cleanly on github.com (table + admonition lines)
- [ ] All 6 links resolve (docs site live, releases page accessible, project board public, CONTRIBUTING.md exists, discussions enabled, good-first-issue label exists)
- [ ] Required checks (repo-validation, link checks) start and pass