### PR TITLE
docs: polish release and citation links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,56 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-### Added
+## v0.1.0-alpha
 
-- (placeholder) The first tag will be `v0.1.0-alpha` — an architecture
-  and specification snapshot of the current `docs/v002/` tree plus the
-  ISA reference (`main.tex` → `_static/downloads/pccx-isa-v002.pdf`).
+First public alpha snapshot of the canonical pccx architecture, ISA,
+and documentation site under the `pccxai` organization. Mirrors the
+release draft at
+[`docs/releases/v0.1.0-alpha.md`](docs/releases/v0.1.0-alpha.md).
+
+### Highlights
+
+- First snapshot of the canonical pccx architecture, ISA, and
+  documentation site under the `pccxai` organization.
+- Bilingual (EN + KO) Sphinx site with `numfig`, MyST and MyST-NB,
+  multiversion publishing, and Furo dark/light theme; live at
+  `https://pccxai.github.io/pccx/`.
+- ISA package (`isa_pkg.sv`) cross-referenced from the docs through
+  `literalinclude` against the `codes/v002/` clone produced at build
+  time from the sibling RTL repository.
+- ISA preprint PDF build (`isa-pdf.yml`, `xelatex`) producing the
+  tracked `_static/downloads/pccx-isa-v002.pdf`.
+- Repo-validation CI (`repo-validate`) covering URL hygiene,
+  brand-name guard, Pages build sanity, and required-checks
+  enforcement on `main`.
+- Three-stage GitHub ruleset on `main` (force-push and branch-deletion
+  block, PR-required, required status checks). Direct push to `main`
+  is blocked.
+- Citation metadata in tree: `CITATION.cff`, `CHANGELOG.md`,
+  `RELEASING.md`.
+
+### Known limitations
+
+- W4A8 throughput numbers in the docs are framed as planning targets,
+  not measured silicon results.
+- v002 RTL is referenced from the `pccxai/pccx-FPGA-NPU-LLM-kv260`
+  sibling repo at build time; this repo does not contain a bitstream
+  or place-and-route closure.
+- The KV cache memory model section is documentation-level; the
+  on-chip layout is described, not benchmarked.
+- v003 architecture is roadmap only; no scaffolding has landed.
+- Localization beyond EN and KO is tracked under
+  `M2 — v0.3 Community Localization` and is not part of this snapshot.
+
+### Validation
+
+- `make strict` builds clean (zero warnings) on EN and KO sources.
+- `make linkcheck` clean on the weekly cron.
+- `repo-validate` required check green on `main`.
+- ISA PDF build green on `main`.
+- Sphinx Pages deploy green; `https://pccxai.github.io/pccx/` returns
+  HTTP 200.
+- No standalone-vendor brand-token leaks in tracked sources
+  (word-boundary scan).
 
 [Unreleased]: https://github.com/pccxai/pccx/compare/HEAD...HEAD

--- a/README.md
+++ b/README.md
@@ -27,8 +27,10 @@ issues are welcome.
 | --- | --- |
 | Documentation | <https://pccxai.github.io/pccx/> |
 | Releases | <https://github.com/pccxai/pccx/releases> |
+| `v0.1.0-alpha` notes | [docs/releases/v0.1.0-alpha.md](docs/releases/v0.1.0-alpha.md) |
 | Roadmap (project board) | <https://github.com/orgs/pccxai/projects/1> |
 | Contributing | [CONTRIBUTING.md](CONTRIBUTING.md) |
+| How to cite | [CITATION.cff](CITATION.cff) |
 | Discussions | <https://github.com/pccxai/pccx/discussions> |
 | Good first issues | <https://github.com/pccxai/pccx/labels/good%20first%20issue> |
 


### PR DESCRIPTION
## Summary

- Add `v0.1.0-alpha` release-notes row and `How to cite` row to the README **Project status** entry-point table so visitors land on the in-tree release draft and `CITATION.cff` without scanning the whole README.
- Replace the placeholder `[Unreleased]` block in `CHANGELOG.md` with a full `v0.1.0-alpha` section (Highlights / Known limitations / Validation) mirroring `docs/releases/v0.1.0-alpha.md` and the GitHub draft release body. No `Draft only` boilerplate is carried over so the CHANGELOG section reads as the canonical post-publish summary.

No tag is created and the GitHub draft release is unchanged. Direct push to `main` is still blocked by the Stage 1/2/3 ruleset.

## Test plan

- [x] `git diff` review — README adds two rows; CHANGELOG replaces placeholder with mirrored content.
- [ ] CI `repo-validate` green on this PR.
- [ ] Visual sanity: README entry-point table renders cleanly on the PR view.