### PR TITLE
docs: update v0.1.0-alpha release links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-## v0.1.0-alpha
+## v0.1.0-alpha — 2026-05-01
 
 First public alpha snapshot of the canonical pccx architecture, ISA,
 and documentation site under the `pccxai` organization. Mirrors the
-release draft at
+release notes at
 [`docs/releases/v0.1.0-alpha.md`](docs/releases/v0.1.0-alpha.md).
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ## Project status
 
-**Public alpha** — first tagged release `v0.1.0-alpha` is in draft. Core
+**Public alpha** — `v0.1.0-alpha` is published as a prerelease. Core
 architecture and ISA are stable; verification, KV260 bring-up, and
 documentation polish are in progress. Expect rough edges; feedback and
 issues are welcome.

--- a/docs/releases/v0.1.0-alpha.md
+++ b/docs/releases/v0.1.0-alpha.md
@@ -2,19 +2,17 @@
 orphan: true
 ---
 
-# pccx v0.1.0-alpha — release draft
+# pccx v0.1.0-alpha — release notes
 
-> **Draft only — do not publish.** No tag is created, no GitHub release
-> is published. This file is a planning document for human review and
-> will be turned into the actual release notes when the v0.1.0-alpha
-> tag is eventually pushed in a separately approved cycle.
+> **Published prerelease.** Tag `v0.1.0-alpha` is pushed and the GitHub
+> Release is live as a prerelease (not marked latest). This page mirrors
+> the release body and is kept here as the in-tree reference.
 
-- **Target repo**: `pccxai/pccx`
-- **Target base SHA**: `f6247e3` (current `main` HEAD as of 2026-05-01,
-  immediately after the citation-metadata cleanup merge)
-- **Title (proposed)**: `pccx v0.1.0-alpha — first public architecture snapshot`
-- **Tag (proposed, NOT created)**: `v0.1.0-alpha`
+- **Repo**: `pccxai/pccx`
+- **Tag**: `v0.1.0-alpha`
+- **Title**: `pccx v0.1.0-alpha — first public architecture snapshot`
 - **Pre-release**: yes
+- **Release link**: <https://github.com/pccxai/pccx/releases/tag/v0.1.0-alpha>
 
 ## Highlights
 
@@ -65,13 +63,11 @@ orphan: true
 
 Cite using the in-repo `CITATION.cff` (author: Hyunwoo Kim,
 Independent researcher; ORCID intentionally omitted until registered).
-This release does not mint a Zenodo DOI yet; that will follow once the
-v0.1.0-alpha tag is actually pushed in a later, separately approved
-cycle.
+This release does not mint a Zenodo DOI yet; DOI minting is deferred
+to a later release.
 
 ## Not included in this release
 
-- Tag push or GitHub Release publication.
 - Zenodo DOI minting.
 - arXiv submission of the ISA preprint.
 - Localization launch (Spanish, Japanese, Chinese) — tracked as

--- a/ko/docs/releases/v0.1.0-alpha.md
+++ b/ko/docs/releases/v0.1.0-alpha.md
@@ -2,19 +2,18 @@
 orphan: true
 ---
 
-# pccx v0.1.0-alpha — 릴리스 초안
+# pccx v0.1.0-alpha — 릴리스 노트
 
-> **초안일 뿐입니다 — 배포하지 마세요.** 태그를 만들지 않으며,
-> GitHub Release도 발행하지 않습니다. 이 파일은 사람 검토를 위한
-> 계획 문서이며, v0.1.0-alpha 태그가 별도 승인 사이클에서 실제로
-> 푸시되는 시점에 릴리스 노트의 본문으로 사용됩니다.
+> **사전 릴리스(prerelease) 게시 완료.** `v0.1.0-alpha` 태그가
+> 푸시되었고, GitHub Release가 prerelease(latest 아님)로 게시되어
+> 있습니다. 이 페이지는 release body를 미러링하며 in-tree 참조용으로
+> 보관됩니다.
 
-- **대상 저장소**: `pccxai/pccx`
-- **기준 SHA**: `f6247e3` (2026-05-01 기준 `main` HEAD,
-  citation-metadata 정리 머지 직후)
-- **제안 제목**: `pccx v0.1.0-alpha — 첫 공개 아키텍처 스냅샷`
-- **제안 태그 (생성하지 않음)**: `v0.1.0-alpha`
+- **저장소**: `pccxai/pccx`
+- **태그**: `v0.1.0-alpha`
+- **제목**: `pccx v0.1.0-alpha — 첫 공개 아키텍처 스냅샷`
 - **사전 릴리스(pre-release)**: 예
+- **릴리스 링크**: <https://github.com/pccxai/pccx/releases/tag/v0.1.0-alpha>
 
 ## 주요 변경 사항
 
@@ -60,12 +59,11 @@ orphan: true
 
 저장소의 `CITATION.cff`를 사용해 인용해 주세요 (저자: Hyunwoo Kim,
 Independent researcher; ORCID는 등록 전이라 의도적으로 비워둠).
-본 릴리스에서는 Zenodo DOI를 발행하지 않으며, v0.1.0-alpha 태그가
-별도 승인 사이클에서 실제로 푸시될 때 발행 예정입니다.
+본 릴리스에서는 Zenodo DOI를 발행하지 않으며, DOI 발행은 향후
+릴리스로 미뤄둡니다.
 
 ## 본 릴리스에 포함되지 않는 것
 
-- 태그 푸시 또는 GitHub Release 발행.
 - Zenodo DOI 발행.
 - ISA preprint의 arXiv 제출.
 - 로컬라이제이션 런칭 (스페인어, 일본어, 중국어). v0.3에서 `lang:*`


### PR DESCRIPTION
## Summary

- v0.1.0-alpha is now published as a prerelease, so the README,
  CHANGELOG, and in-tree release notes should describe it as such.
- Drops "draft" / "do not publish" / "tag not yet created" wording.
- Adds the actual published prerelease URL to the release notes.
- Removes the `tag push or GitHub Release publication` bullet from
  the "Not included in this release" list.

## Test plan

- [ ] `make strict` (or repo equivalent) builds clean.
- [ ] `repo-validate` passes.
- [ ] No new vendor / brand tokens introduced.