### PR TITLE
docs: update systemverilog-ide roadmap references

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -18,7 +18,7 @@ Tracking issue: [pccxai/pccx#28 — v0.2.0 umbrella][v020].
 
 - pccx-lab plugin system (CLI-first, GUI second)
 - controlled MCP interface for AI workers
-- spin out `pccx-systemverilog-ide` from pccx-lab
+- spin out `systemverilog-ide` from pccx-lab
 - `pccx-llm-launcher` MVP planning
 - pccx-lab ↔ IDE handoff format
 - pccx-lab ↔ launcher workflow boundary

--- a/ko/docs/roadmap.md
+++ b/ko/docs/roadmap.md
@@ -17,7 +17,7 @@ pccx 생태계 전체의 현재 릴리스 방향만 짧게 요약한다.
 
 - pccx-lab plugin system (CLI 우선, GUI 후속)
 - AI worker 를 위한 controlled MCP 인터페이스
-- pccx-lab 에서 `pccx-systemverilog-ide` 를 spin-out
+- pccx-lab 에서 `systemverilog-ide` 를 spin-out
 - `pccx-llm-launcher` MVP 기획
 - pccx-lab ↔ IDE handoff 포맷
 - pccx-lab ↔ launcher workflow boundary


### PR DESCRIPTION
## Changes

Update stale references from old repo name `pccx-systemverilog-ide` to canonical name `systemverilog-ide` in roadmap docs (EN and KO).

## Notes

- No new roadmap content added.
- Wording remains grounded — no stable IDE/API/KV260 inference claims.
- No vendor-specific AI wording introduced.