### PR TITLE
docs: use evidence-gated public wording on index

### DIFF
--- a/docs/v002/RTL/controller.rst
+++ b/docs/v002/RTL/controller.rst
@@ -1,6 +1,5 @@
 :rtl_source: hw/rtl/NPU_Controller/npu_controller_top.sv,
              hw/rtl/NPU_Controller/NPU_Control_Unit/ctrl_npu_decoder.sv,
-             hw/rtl/NPU_Controller/NPU_Control_Unit/ctrl_npu_dispatcher.sv,
              hw/rtl/NPU_Controller/Global_Scheduler.sv
 
 ============================
@@ -11,7 +10,7 @@ NPU Controller Modules
 ==================
 
 ``npu_controller_top.sv`` integrates the AXI-Lite frontend, instruction
-decoder, dispatcher, and global scheduler into a single unit.
+decoder, and global scheduler into a single controller boundary.
 
 .. literalinclude:: ../../../codes/v002/hw/rtl/NPU_Controller/npu_controller_top.sv
    :language: systemverilog
@@ -28,21 +27,11 @@ typed struct (``GEMV_op_x64_t``, ``memcpy_op_x64_t``, etc.).
    :language: systemverilog
    :caption: hw/rtl/NPU_Controller/NPU_Control_Unit/ctrl_npu_decoder.sv
 
-3. Instruction Dispatcher
-==========================
-
-``ctrl_npu_dispatcher.sv`` resolves Constant Cache pointer lookups
-(shape / size / scale), checks for address and resource hazards, and
-issues per-core control μops to GEMM, GEMV, CVO, and mem_dispatcher.
-
-.. literalinclude:: ../../../codes/v002/hw/rtl/NPU_Controller/NPU_Control_Unit/ctrl_npu_dispatcher.sv
-   :language: systemverilog
-   :caption: hw/rtl/NPU_Controller/NPU_Control_Unit/ctrl_npu_dispatcher.sv
-
-4. Global Scheduler
+3. Global Scheduler
 ====================
 
-``Global_Scheduler.sv`` tracks in-flight async instructions, maintains
+``Global_Scheduler.sv`` receives decoded instruction fields, emits
+per-core control μops, tracks in-flight async instructions, maintains
 the dependency scoreboard, and gates new dispatches when a hazard is
 detected.
 
@@ -53,6 +42,8 @@ detected.
 .. admonition:: Last verified against
    :class: note
 
-   Commit ``773bd82`` @ ``pccxai/pccx-FPGA-NPU-LLM-kv260`` (2026-04-21).
+   Current public ``pccx-FPGA-NPU-LLM-kv260`` ``main`` clone used by the
+   documentation CI. Controller source references should stay aligned with
+   files present in that public RTL tree.
 
 .. seealso:: :doc:`/docs/v002/ISA/dataflow` — dependency and completion tracking.

--- a/index.rst
+++ b/index.rst
@@ -26,10 +26,10 @@ Ecosystem
       compute cores (GEMM / GEMV / CVO), memory hierarchy. Target device
       is the Xilinx Kria **KV260** (Zynq UltraScale+ ZU5EV).
 
-      **Currently supported (focus):** Gemma-3N E4B @ W4A8KV4 — tok/s
-      pending KV260 board run (see :doc:`docs/Evidence/index`).
-      Everything else (v003 / Gemma-4 / Llama) lives on the
-      :doc:`docs/roadmap`.
+      **Current focus:** Gemma-3N E4B @ W4A8KV4 remains an evidence-gated
+      target. Token-rate, board-run, and timing-closure results are pending
+      measured KV260 evidence (see :doc:`docs/Evidence/index`). Everything
+      else (v003 / Gemma-4 / Llama) lives on the :doc:`docs/roadmap`.
 
       Every v002 RTL reference page on this site links back to the exact
       ``.sv`` file in that repository.
@@ -64,12 +64,12 @@ Tooling & Lab
    .. grid-item-card:: :octicon:`beaker;1.2em;sd-mr-1` pccx-lab
       :link: https://pccxai.github.io/pccx/en/lab/
       :link-type: url
-      :link-alt: Open the pccx-lab simulator and profiler
+      :link-alt: Open the pccx-lab verification lab
       :class-card: pccx-lab-card
 
-      Performance simulator and AI-integrated profiler, built for the pccx NPU.
-      Pre-RTL bottleneck detection, UVM co-simulation, and LLM-driven testbench
-      generation in one workflow.
+      CLI-first verification lab for pccx traces, reports, diagnostics,
+      and workflow boundaries. GUI, IDE, launcher, and future MCP surfaces
+      should reuse the same CLI / core boundary instead of duplicating logic.
 
       :bdg-warning:`Work in Progress`
 
@@ -140,4 +140,4 @@ Tooling & Lab
    :maxdepth: 1
    :caption: Tools
 
-   pccx-lab — Simulator & AI Profiler <https://pccxai.github.io/pccx/en/lab/>
+   pccx-lab — Verification Lab <https://pccxai.github.io/pccx/en/lab/>

--- a/ko/docs/v002/RTL/controller.rst
+++ b/ko/docs/v002/RTL/controller.rst
@@ -1,6 +1,5 @@
 :rtl_source: hw/rtl/NPU_Controller/npu_controller_top.sv,
              hw/rtl/NPU_Controller/NPU_Control_Unit/ctrl_npu_decoder.sv,
-             hw/rtl/NPU_Controller/NPU_Control_Unit/ctrl_npu_dispatcher.sv,
              hw/rtl/NPU_Controller/Global_Scheduler.sv
 
 ============================
@@ -11,7 +10,7 @@ NPU 컨트롤러 모듈
 ===================
 
 ``npu_controller_top.sv``\는 AXI-Lite 프론트엔드, 명령어 디코더,
-디스패처, 글로벌 스케줄러를 하나의 단위로 통합한다.
+글로벌 스케줄러를 단일 컨트롤러 경계로 통합한다.
 
 .. literalinclude:: ../../../../codes/v002/hw/rtl/NPU_Controller/npu_controller_top.sv
    :language: systemverilog
@@ -28,22 +27,12 @@ NPU 컨트롤러 모듈
    :language: systemverilog
    :caption: hw/rtl/NPU_Controller/NPU_Control_Unit/ctrl_npu_decoder.sv
 
-3. 명령어 디스패처
+3. 글로벌 스케줄러
 ===================
 
-``ctrl_npu_dispatcher.sv``\는 Constant Cache 포인터 조회(shape/size/scale)를
-수행하고, 주소 및 리소스 해저드를 검사하며, 각 코어(GEMM, GEMV, CVO,
-mem_dispatcher)에 제어 μop을 발행한다.
-
-.. literalinclude:: ../../../../codes/v002/hw/rtl/NPU_Controller/NPU_Control_Unit/ctrl_npu_dispatcher.sv
-   :language: systemverilog
-   :caption: hw/rtl/NPU_Controller/NPU_Control_Unit/ctrl_npu_dispatcher.sv
-
-4. 글로벌 스케줄러
-===================
-
-``Global_Scheduler.sv``\는 in-flight 비동기 명령어를 추적하고,
-의존성 스코어보드를 유지하며, 해저드 감지 시 새 디스패치를 게이팅한다.
+``Global_Scheduler.sv``\는 디코더에서 전달된 명령어 필드를 받아 각 코어에
+대한 제어 μop을 발행하고, in-flight 비동기 명령어를 추적하며, 의존성
+스코어보드를 유지하고, 해저드 감지 시 새 디스패치를 게이팅한다.
 
 .. literalinclude:: ../../../../codes/v002/hw/rtl/NPU_Controller/Global_Scheduler.sv
    :language: systemverilog
@@ -52,6 +41,8 @@ mem_dispatcher)에 제어 μop을 발행한다.
 .. admonition:: 마지막 검증 대상
    :class: note
 
-   커밋 ``773bd82`` @ ``pccxai/pccx-FPGA-NPU-LLM-kv260`` (2026-04-21).
+   문서 CI가 사용하는 공개 ``pccx-FPGA-NPU-LLM-kv260`` ``main`` 클론을
+   기준으로 한다. 컨트롤러 소스 참조는 해당 공개 RTL 트리에 존재하는
+   파일과 일관성을 유지해야 한다.
 
 .. seealso:: :doc:`/docs/v002/ISA/dataflow` — 의존성·완료 추적.


### PR DESCRIPTION
## Summary

- Replace AI-looking pccx-lab wording on the public documentation index with CLI-first verification lab wording.
- Clarify that Gemma-3N E4B / KV260 token-rate, board-run, and timing-closure results remain evidence-gated targets.
- Rename the tools link label from AI-profiler style wording to verification-lab wording.

## Scope

- `index.rst` only.
- Public wording cleanup only.
- No roadmap, release, tag, benchmark, hardware, FPGA, or runtime behavior changes.

## Non-goals

- No claim that KV260 inference works.
- No claim that Gemma 3N E4B runs on KV260.
- No claim that 20 tok/s is achieved.
- No timing-closed, production-ready, stable release, marketplace-ready, or stable API/ABI claim.
- No long roadmap rewrite in this PR.

## Validation

Suggested local validation before merge:

```bash
git diff --check
make strict
make lint
```

## Notes

This is a small public-surface hygiene PR. A separate README cleanup PR should remove or reduce the long week-based roadmap table and align README status wording with the current evidence-gated v0.2.0 track.