### PR TITLE
docs: scaffold v003 LLM and vision-v001 tracks

### DIFF
--- a/_static/diagrams/pccx_family_tree.svg
+++ b/_static/diagrams/pccx_family_tree.svg
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 460" role="img">
+  <title>pccx product family tree — versions and tracks</title>
+
+  <defs>
+    <marker id="arr-pft" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#000000"/>
+    </marker>
+    <style><![CDATA[
+      text { fill: #000000; font: 400 12px ui-sans-serif, system-ui, sans-serif; }
+      .t-title  { font-weight: 600; font-size: 13px; text-anchor: middle; }
+      .t-spec   { font-size: 10px; fill: #444444; text-anchor: middle; }
+      .t-stage  { font-weight: 600; font-size: 11px; text-anchor: start; }
+
+      .block-archived { fill: #e6e6e6; stroke: #000000; stroke-width: 0.8; }
+      .block-active   { fill: #e2efd8; stroke: #000000; stroke-width: 0.8; }
+      .block-working  { fill: #fce5c6; stroke: #000000; stroke-width: 0.8; }
+      .block-parallel { fill: #dae7f4; stroke: #000000; stroke-width: 0.8; }
+
+      .line-main   { stroke: #000000; stroke-width: 1.2; fill: none; marker-end: url(#arr-pft); }
+      .line-branch { stroke: #000000; stroke-width: 1; fill: none; marker-end: url(#arr-pft); stroke-dasharray: 4 2; }
+
+      g.node rect { transition: stroke-width 120ms; }
+      g.node:hover rect { stroke-width: 2; }
+    ]]></style>
+  </defs>
+
+  <rect x="0" y="0" width="1000" height="460" fill="#ffffff"/>
+
+  <text class="t-stage" x="40" y="38">pccx product family tree</text>
+
+  <rect class="block-archived" x="40" y="52" width="20" height="14"/>
+  <text class="t-spec" x="65" y="63" text-anchor="start">archived</text>
+  <rect class="block-active" x="135" y="52" width="20" height="14"/>
+  <text class="t-spec" x="160" y="63" text-anchor="start">active</text>
+  <rect class="block-working" x="220" y="52" width="20" height="14"/>
+  <text class="t-spec" x="245" y="63" text-anchor="start">working (not yet)</text>
+  <rect class="block-parallel" x="355" y="52" width="20" height="14"/>
+  <text class="t-spec" x="380" y="63" text-anchor="start">parallel track</text>
+
+  <text class="t-stage" x="22" y="160" transform="rotate(-90 22 160)">LLM line</text>
+  <text class="t-stage" x="22" y="350" transform="rotate(-90 22 350)">vision line</text>
+
+  <g class="node">
+    <rect class="block-archived" x="60" y="180" width="140" height="60"/>
+    <text class="t-title" x="130" y="205">v001</text>
+    <text class="t-spec"  x="130" y="222">archived</text>
+    <text class="t-spec"  x="130" y="234">prior NPU PoC</text>
+    <title>v001 — Archived. Original NPU proof of concept; preserved under docs/archive/experimental_v001/.</title>
+  </g>
+
+  <g class="node">
+    <rect class="block-active" x="240" y="180" width="160" height="60"/>
+    <text class="t-title" x="320" y="205">v002 (KV260 LLM)</text>
+    <text class="t-spec"  x="320" y="222">pccx-FPGA-NPU-LLM-kv260</text>
+    <text class="t-spec"  x="320" y="234">W4A8 NPU substrate</text>
+    <title>v002 — Active LLM line on KV260. Repository: pccx-FPGA-NPU-LLM-kv260. W4A8 (INT4 weight × INT8 activation) NPU substrate. Shared by all downstream tracks.</title>
+  </g>
+
+  <g class="node">
+    <rect class="block-active" x="440" y="100" width="140" height="60"/>
+    <text class="t-title" x="510" y="125">v002.0</text>
+    <text class="t-spec"  x="510" y="142">baseline integration</text>
+    <text class="t-spec"  x="510" y="154">in progress</text>
+    <title>v002.0 — KV260 baseline integration. Phase 3 step 1 (shape constant RAM unification) and Stage C cleanup are in progress. Throughput is measured-only on this release line.</title>
+  </g>
+
+  <g class="node">
+    <rect class="block-active" x="620" y="100" width="140" height="60"/>
+    <text class="t-title" x="690" y="125">v002.1</text>
+    <text class="t-spec"  x="690" y="142">sparsity + spec.</text>
+    <text class="t-spec"  x="690" y="154">decoding</text>
+    <title>v002.1 — sparsity + speculative decoding stack on the same RTL repository. EAGLE-3 / SSD / Tree / benchmark phases. 20 tok/s target lives on this release line.</title>
+  </g>
+
+  <g class="node">
+    <rect class="block-working" x="800" y="100" width="160" height="60"/>
+    <text class="t-title" x="880" y="125">v003</text>
+    <text class="t-spec"  x="880" y="142">pccx-LLM-v003</text>
+    <text class="t-spec"  x="880" y="154">Gemma 4 E4B foundation</text>
+    <title>v003 — LLM line continued on a separate RTL repository. Working name pccx-LLM-v003. Gemma 4 E4B foundation; one architectural novelty per release point.</title>
+  </g>
+
+  <g class="node">
+    <rect class="block-parallel" x="440" y="320" width="160" height="60"/>
+    <text class="t-title" x="520" y="345">vision-v001</text>
+    <text class="t-spec"  x="520" y="362">pccx-vision-v001</text>
+    <text class="t-spec"  x="520" y="374">CNN inference track</text>
+    <title>vision-v001 — Parallel CNN inference track on the same KV260 substrate. Working name pccx-vision-v001. First model candidates: ResNet18 / YOLOv8n / MobileNetV3.</title>
+  </g>
+
+  <line class="line-main" x1="200" y1="210" x2="240" y2="210"/>
+  <path class="line-main" d="M 400 200 Q 420 165 440 130"/>
+  <line class="line-main" x1="580" y1="130" x2="620" y2="130"/>
+  <line class="line-main" x1="760" y1="130" x2="800" y2="130"/>
+  <path class="line-branch" d="M 400 220 Q 420 280 440 350"/>
+
+</svg>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -160,3 +160,9 @@ risks, keeping the ecosystem safe for open-source hardware development.
 .. |Architecture| image:: https://img.shields.io/badge/Architecture-Scalable_NPU-purple
 .. |Target| image:: https://img.shields.io/badge/Target-Edge_AI-orange
 .. |Precision| image:: https://img.shields.io/badge/Precision-W4A8_Promotion-green
+
+.. toctree::
+   :hidden:
+
+   v003/index
+   vision-v001/index

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -3,10 +3,12 @@
 The detailed execution board lives in [GitHub Projects][project]. This page
 only summarizes the current release direction across the pccx ecosystem.
 
-The release cadence is staged on a shared KV260 bitstream harness. v002.0
-is the baseline integration; v002.1 layers sparsity and speculative
-decoding on the same RTL; v003.x moves to a separate RTL repository as
-architectural novelties land.
+The release cadence is staged on a shared KV260 bitstream harness.
+v002.0 is the baseline integration; v002.1 layers sparsity and
+speculative decoding on the same RTL; v003.x moves to a separate RTL
+repository as architectural novelties land. A parallel **vision-v001**
+track shares the same KV260 substrate but covers CNN-class workloads
+(classification / detection) and lives on its own repository.
 
 ## Now — v002.0: baseline integration on KV260
 
@@ -45,17 +47,50 @@ Tracking issue: [pccxai/pccx#28 — v0.2.0 umbrella][v020].
 - compute budget for EAGLE head training: $70–100 ($40 if a TRC TPU
   grant lands)
 
-## Later — v003.x: separate RTL repository
+## Later — v003.x: separate RTL repository (LLM line continued)
 
 - v003+ active RTL development moves to a dedicated repository, working
-  name `pccx-FPGA-NPU-LLM-v003`, public URL TBD; the v003 RTL
-  repository has not been created yet
-- this docs repo will cross-link the v003 RTL repository and CI-clone it
-  into `codes/v003/` at build time, the same way it currently CI-clones
-  `pccx-FPGA-NPU-LLM-kv260` into `codes/v002/`
+  name `pccx-LLM-v003`, public URL TBD; the v003 RTL repository has
+  not yet stabilised any release branch
+- this docs repo will cross-link the v003 RTL repository and CI-clone
+  it into `codes/v003/` at build time, the same way it currently
+  CI-clones `pccx-FPGA-NPU-LLM-kv260` into `codes/v002/`
 - v003.0 — Gemma 4 E4B foundation + first architectural novelty;
   throughput TBD
-- v003.1 — second novelty + KV/decoding co-design; throughput TBD
+- v003.1 — second novelty + KV / decoding co-design; throughput TBD
+- placeholder track index: {doc}`v003/index`
+
+## Parallel — vision-v001: CNN inference track on KV260
+
+A second product line scoped to **vision** workloads shares the same
+KV260 board and the W4A8 NPU substrate but covers a distinct workload
+family from the LLM line. Active RTL development will live in a
+dedicated repository.
+
+- working name `pccx-vision-v001`, public URL TBD
+- shared substrate with the LLM line — same KV260 board, same W4A8
+  weight × activation ratio, same L2 URAM organisation
+- distinct dataflow — dense-conv tile reuse instead of token-by-token
+  KV streaming; the GEMM systolic + GEMV hybrid is reused for conv
+- first model candidates — ResNet18 / YOLOv8n / MobileNetV3
+  (smallest-footprint variants first)
+- evidence posture — the same release evidence checklist gates
+  timing / throughput / bring-up before any FPS or mAP figure lands
+  on this docs site
+- placeholder track index: {doc}`vision-v001/index`
+
+## Family overview
+
+```{figure} ../_static/diagrams/pccx_family_tree.svg
+:name: fig-pccx-family-tree-en
+:alt: pccx product family tree across versions and tracks
+
+v001 (archived) → v002 (active KV260 LLM line: v002.0 → v002.1) →
+v003.x (LLM line continued, separate RTL repository). The
+**vision-v001** track branches at the v002 KV260 substrate and runs
+in parallel on its own repository. Hover any node for status and
+scope.
+```
 
 ## Links
 

--- a/docs/v003/index.md
+++ b/docs/v003/index.md
@@ -1,0 +1,44 @@
+# pccx v003 — LLM line, separate RTL repository
+
+The v003 line continues the **LLM track** from the
+{doc}`v002 line <../v002/index>` on a dedicated RTL repository.
+Active code is not yet present in this docs site — this page is a
+placeholder while the upstream RTL repository stabilises.
+
+## Working state
+
+- working repository name: `pccx-LLM-v003`, public URL TBD
+- working staging repository: `pccx-LLM-v003-staging` (private)
+- repositories created in evidence-tracked state; no release branch
+  has stabilised yet
+- shared substrate with v002 — same KV260 board, same W4A8 weight ×
+  activation ratio, same L2 URAM organisation
+- first model focus — **Gemma 4 E4B** as the foundation, with one
+  architectural novelty layered on top per release point (v003.0,
+  v003.1)
+- v002.x phases (sparsity, speculative, EAGLE, SSD, Tree, benchmark)
+  are *not* repeated here; v003 starts from a different RTL baseline
+
+## Status snapshot
+
+```{table} v003 layer status (placeholder)
+:name: tbl-v003-status-en
+
+| Layer            | State                                                           |
+|---|---|
+| RTL              | not yet committed in the v003 repository                        |
+| Driver / runtime | shared API surface with v002; no v003-specific path yet         |
+| Verification     | inherits the v002 evidence checklist as its release gate        |
+| Throughput claim | none — TBD                                                      |
+| Timing closure   | none — TBD                                                      |
+| Bitstream        | none — TBD                                                      |
+```
+
+This page will be expanded as the upstream RTL repository lands.
+
+## See also
+
+- {doc}`../roadmap` — release direction across the pccx ecosystem
+- {doc}`../v002/index` — current active LLM line (KV260)
+- {doc}`../vision-v001/index` — parallel vision track on the same
+  substrate

--- a/docs/vision-v001/index.md
+++ b/docs/vision-v001/index.md
@@ -1,0 +1,69 @@
+# pccx vision-v001 — CNN inference track on KV260
+
+The vision-v001 line is a parallel product line on the same KV260
+substrate, scoped to **vision** workloads (CNN-class classification,
+object detection). It shares the W4A8 NPU substrate with the LLM
+line but covers a distinct workload family. Active code is not yet
+present in this docs site — this page is a placeholder while the
+upstream RTL repository stabilises.
+
+## Working state
+
+- working repository name: `pccx-vision-v001`, public URL TBD
+- working staging repository: `pccx-vision-v001-staging` (private)
+- shared substrate with v002 — same KV260 board, same W4A8 weight ×
+  activation ratio, same L2 URAM organisation
+- distinct dataflow — dense-conv tile reuse instead of token-by-token
+  KV streaming; the GEMM systolic + GEMV hybrid is reused for conv
+- first model candidates — ResNet18, YOLOv8n, MobileNetV3
+  (smallest-footprint variants first; choice is driven by the L2
+  URAM and DSP budget on KV260)
+
+## Position relative to existing FPGA vision IPs
+
+The KV260 vision landscape today is occupied by two large families
+of IP: vendor-supplied DPU IP (INT8-only) and arbitrary-bit
+streaming-dataflow accelerators driven by quantisation-aware training
+(QAT). The vision-v001 track positions itself differently from both,
+on three axes.
+
+```{table} vision-v001 differentiation matrix (landscape context, not a benchmark)
+:name: tbl-vision-v001-differentiation-en
+
+| Axis                    | Commodity DPU IP (INT8-only) | Streaming-dataflow QAT (FINN-class) | vision-v001 (this track)               |
+|---|---|---|---|
+| Quantisation            | INT8 weights / INT8 activations | arbitrary 2–8 bit, QAT              | **W4A8** — INT4 weight × INT8 act   |
+| Dataflow                | heterogeneous micro-coded PE mix | per-layer streaming dataflow        | unified GEMM systolic + GEMV         |
+| Reuse with LLM line     | none                            | none                                | **same RTL substrate as v002**       |
+| Per-layer efficiency    | reported 5–9× variance across stages | high but model-specific build       | designed for tile-reuse uniformity   |
+| Source                  | vendor reference                | open-source (e.g. FINN), QAT toolchain | open-source, KV260-native            |
+```
+
+The differentiation is *posture*, not a benchmark — no FPS, latency,
+power, or accuracy figure is claimed on this page until the release
+evidence checklist gates it in. References to existing vendor / QAT
+IPs are landscape context only.
+
+## Status snapshot
+
+```{table} vision-v001 layer status (placeholder)
+:name: tbl-vision-v001-status-en
+
+| Layer              | State                                                            |
+|---|---|
+| RTL                | not yet committed in the vision-v001 repository                  |
+| Driver / runtime   | scope TBD; conv-specific path likely diverges from v002          |
+| Verification       | inherits the v002 evidence checklist; per-model golden vectors TBD |
+| FPS claim          | none — TBD                                                       |
+| mAP / Top-1 claim  | none — TBD                                                       |
+| Bitstream          | none — TBD                                                       |
+```
+
+This page will be expanded as the upstream RTL repository lands and
+the first model is profiled.
+
+## See also
+
+- {doc}`../roadmap` — release direction across the pccx ecosystem
+- {doc}`../v002/index` — shared NPU substrate (active LLM line)
+- {doc}`../v003/index` — LLM line continued, separate RTL repository

--- a/ko/docs/index.rst
+++ b/ko/docs/index.rst
@@ -141,3 +141,9 @@ v001 레퍼런스 아키텍처는 :doc:`archive/experimental_v001/index` 에 보
 .. |Architecture| image:: https://img.shields.io/badge/Architecture-Scalable_NPU-purple
 .. |Target| image:: https://img.shields.io/badge/Target-Edge_AI-orange
 .. |Precision| image:: https://img.shields.io/badge/Precision-W4A8_Promotion-green
+
+.. toctree::
+   :hidden:
+
+   v003/index
+   vision-v001/index

--- a/ko/docs/roadmap.md
+++ b/ko/docs/roadmap.md
@@ -6,7 +6,9 @@ pccx 생태계 전체의 현재 릴리스 방향만 짧게 요약한다.
 릴리스 cadence 는 공통 KV260 비트스트림 하니스 위에서 단계적으로
 나뉜다. v002.0 은 베이스라인 통합, v002.1 은 동일 RTL 위에 sparsity
 + speculative decoding 스택을 얹는 단계, v003.x 는 새로운 아키텍처
-novelty 가 등장하면서 별도 RTL 저장소로 옮겨가는 단계다.
+novelty 가 등장하면서 별도 RTL 저장소로 옮겨가는 단계다. 또
+하나의 평행 트랙 **vision-v001** 은 같은 KV260 기반 위에 CNN 계열
+워크로드 (분류 / 검출) 를 얹으며, 자체 저장소를 가진다.
 
 ## Now — v002.0: KV260 베이스라인 통합
 
@@ -45,17 +47,48 @@ KV260 bring-up `[HW]` → 런타임 `[HW]` → 릴리스 증거 체크리스트
 - EAGLE head 학습용 컴퓨트 예산: $70–100 (TRC TPU grant 가
   들어오면 $40)
 
-## Later — v003.x: 별도 RTL 저장소
+## Later — v003.x: 별도 RTL 저장소 (LLM 라인 후속)
 
 - v003+ 의 활성 RTL 개발은 별도 저장소로 분리, 작업 이름
-  `pccx-FPGA-NPU-LLM-v003`, 공개 URL 미정; v003 RTL 저장소는 아직
-  생성되지 않았다
+  `pccx-LLM-v003`, 공개 URL 미정; v003 RTL 저장소는 아직 안정된
+  릴리스 브랜치를 가지지 않았다
 - 이 문서 저장소는 v003 RTL 저장소를 cross-link 하고 빌드 시
   `codes/v003/` 로 CI-clone 한다 — 현재
   `pccx-FPGA-NPU-LLM-kv260` 를 `codes/v002/` 로 CI-clone 하는 것과
   같은 방식
 - v003.0 — Gemma 4 E4B 파운데이션 + 첫 아키텍처 novelty; 처리량 TBD
-- v003.1 — 두 번째 novelty + KV/디코딩 co-design; 처리량 TBD
+- v003.1 — 두 번째 novelty + KV / 디코딩 co-design; 처리량 TBD
+- 트랙 placeholder 인덱스: {doc}`v003/index`
+
+## Parallel — vision-v001: KV260 위 CNN 추론 트랙
+
+LLM 라인과는 별개로, **vision** 워크로드 전용 두 번째 제품 라인을
+운영한다. 동일한 KV260 보드와 W4A8 NPU 기반을 공유하면서도 워크
+로드 family 는 다르다. 활성 RTL 개발은 전용 저장소에서 진행된다.
+
+- 작업 이름 `pccx-vision-v001`, 공개 URL 미정
+- LLM 라인과 substrate 공유 — 같은 KV260 보드, 같은 W4A8
+  weight × activation 비율, 같은 L2 URAM 구성
+- 데이터플로우는 다름 — 토큰 단위 KV 스트리밍이 아니라 dense conv
+  타일 재사용. GEMM systolic + GEMV 하이브리드는 conv 에 재사용
+- 첫 모델 후보 — ResNet18 / YOLOv8n / MobileNetV3
+  (footprint 가 가장 작은 변종 우선)
+- 증거 자세 — 동일한 릴리스 증거 체크리스트가 타이밍 / 처리량 /
+  bring-up 게이트 역할. FPS / mAP 수치는 게이트 통과 시점에만 이
+  문서 사이트에 등장
+- 트랙 placeholder 인덱스: {doc}`vision-v001/index`
+
+## Family overview
+
+```{figure} ../../_static/diagrams/pccx_family_tree.svg
+:name: fig-pccx-family-tree-ko
+:alt: pccx 제품군 트리 — 버전과 트랙별 분기
+
+v001 (archived) → v002 (활성 KV260 LLM 라인: v002.0 → v002.1) →
+v003.x (LLM 라인 후속, 별도 RTL 저장소). **vision-v001** 트랙은
+v002 KV260 substrate 에서 분기되어 자체 저장소에서 평행하게
+진행된다. 노드에 hover 하면 상태와 범위가 표시된다.
+```
 
 ## 링크
 

--- a/ko/docs/v003/index.md
+++ b/ko/docs/v003/index.md
@@ -1,0 +1,43 @@
+# pccx v003 — LLM 라인 후속, 별도 RTL 저장소
+
+v003 라인은 {doc}`v002 라인 <../v002/index>` 의 **LLM 트랙**을
+별도 RTL 저장소에서 이어간다. 활성 코드는 아직 이 문서 사이트에
+들어오지 않았으며, 본 페이지는 업스트림 RTL 저장소가 안정될
+때까지의 placeholder 다.
+
+## 작업 상태
+
+- 작업 저장소 이름: `pccx-LLM-v003`, 공개 URL 미정
+- 작업 staging 저장소: `pccx-LLM-v003-staging` (private)
+- 저장소는 evidence-tracked 상태로 생성됨; 안정된 릴리스 브랜치는
+  아직 없음
+- v002 와 substrate 공유 — 동일한 KV260 보드, 동일한 W4A8
+  weight × activation 비율, 동일한 L2 URAM 구성
+- 첫 모델 집중 — **Gemma 4 E4B** 를 파운데이션으로 두고, 릴리스
+  포인트마다 (v003.0, v003.1) 아키텍처 novelty 한 가지씩 적층
+- v002.x 의 단계 (sparsity, speculative, EAGLE, SSD, Tree,
+  benchmark) 는 여기서 *반복하지 않음*; v003 는 다른 RTL
+  베이스라인에서 시작한다
+
+## 상태 스냅샷
+
+```{table} v003 레이어 상태 (placeholder)
+:name: tbl-v003-status-ko
+
+| 레이어               | 상태                                                          |
+|---|---|
+| RTL                  | v003 저장소에 아직 commit 되지 않음                            |
+| 드라이버 / 런타임    | v002 와 API 표면 공유; v003 전용 경로는 아직 없음              |
+| 검증                 | v002 의 릴리스 증거 체크리스트를 게이트로 상속                 |
+| 처리량 주장          | 없음 — TBD                                                    |
+| 타이밍 클로저        | 없음 — TBD                                                    |
+| 비트스트림           | 없음 — TBD                                                    |
+```
+
+이 페이지는 업스트림 RTL 저장소가 자리 잡으면 확장된다.
+
+## 함께 보기
+
+- {doc}`../roadmap` — pccx 생태계의 릴리스 방향 요약
+- {doc}`../v002/index` — 현재 활성 LLM 라인 (KV260)
+- {doc}`../vision-v001/index` — 같은 substrate 위 평행 vision 트랙

--- a/ko/docs/vision-v001/index.md
+++ b/ko/docs/vision-v001/index.md
@@ -1,0 +1,69 @@
+# pccx vision-v001 — KV260 위 CNN 추론 트랙
+
+vision-v001 라인은 동일한 KV260 substrate 위에서 운영되는 평행
+제품 라인으로, **vision** 워크로드 (CNN 계열 분류, 객체 검출) 에
+초점을 둔다. LLM 라인과 W4A8 NPU substrate 를 공유하지만 워크
+로드 family 는 다르다. 활성 코드는 아직 이 문서 사이트에 들어
+오지 않았으며, 본 페이지는 업스트림 RTL 저장소가 안정될 때까지의
+placeholder 다.
+
+## 작업 상태
+
+- 작업 저장소 이름: `pccx-vision-v001`, 공개 URL 미정
+- 작업 staging 저장소: `pccx-vision-v001-staging` (private)
+- v002 와 substrate 공유 — 동일한 KV260 보드, 동일한 W4A8
+  weight × activation 비율, 동일한 L2 URAM 구성
+- 데이터플로우는 다름 — 토큰 단위 KV 스트리밍이 아니라 dense
+  conv 타일 재사용. GEMM systolic + GEMV 하이브리드는 conv 에
+  재사용
+- 첫 모델 후보 — ResNet18, YOLOv8n, MobileNetV3
+  (footprint 가 가장 작은 변종 우선; 선택은 KV260 의 L2 URAM 과
+  DSP 예산에 좌우)
+
+## 기존 FPGA vision IP 대비 위치
+
+오늘날 KV260 vision 영역은 두 부류의 IP 가 차지한다 — 벤더 제공
+DPU IP (INT8 전용) 와 양자화 인지 훈련 (QAT) 으로 구동되는 임의
+비트 streaming-dataflow 가속기. vision-v001 트랙은 양쪽과 다르게
+세 축에서 위치를 잡는다.
+
+```{table} vision-v001 차별화 매트릭스 (비교 맥락, 벤치마크 아님)
+:name: tbl-vision-v001-differentiation-ko
+
+| 축                       | 상용 DPU IP (INT8 전용)     | streaming-dataflow QAT (FINN 계열) | vision-v001 (본 트랙)                |
+|---|---|---|---|
+| 양자화                   | INT8 weight / INT8 activation | 임의 2–8 비트, QAT                  | **W4A8** — INT4 weight × INT8 act |
+| 데이터플로우             | 이종 micro-coded PE 혼합    | 레이어별 streaming dataflow        | 통합 GEMM systolic + GEMV          |
+| LLM 라인과의 재사용      | 없음                        | 없음                               | **v002 와 동일 RTL substrate**     |
+| 레이어별 효율 편차       | 보고된 5–9× 변동             | 모델별 빌드에 좌우                  | 타일 재사용 균일성을 설계 목표로    |
+| 소스                     | 벤더 레퍼런스                | 오픈소스 (예: FINN), QAT 툴체인     | 오픈소스, KV260 네이티브           |
+```
+
+차별화는 *자세 (posture)* 이지 벤치마크가 아니다 — 릴리스 증거
+체크리스트가 게이트를 통과시키기 전까지 FPS / 레이턴시 / 전력 /
+정확도 수치를 이 페이지에서 주장하지 않는다. 기존 벤더 / QAT IP
+참조는 풍경 맥락이지 비교 결과가 아니다.
+
+## 상태 스냅샷
+
+```{table} vision-v001 레이어 상태 (placeholder)
+:name: tbl-vision-v001-status-ko
+
+| 레이어                  | 상태                                                            |
+|---|---|
+| RTL                     | vision-v001 저장소에 아직 commit 되지 않음                      |
+| 드라이버 / 런타임       | 범위 TBD; conv 전용 경로는 v002 와 갈라질 가능성                |
+| 검증                    | v002 릴리스 증거 체크리스트 상속; 모델별 골든 벡터 TBD           |
+| FPS 주장                | 없음 — TBD                                                     |
+| mAP / Top-1 주장        | 없음 — TBD                                                     |
+| 비트스트림              | 없음 — TBD                                                     |
+```
+
+이 페이지는 업스트림 RTL 저장소가 자리 잡고 첫 모델 프로파일링이
+나오면 확장된다.
+
+## 함께 보기
+
+- {doc}`../roadmap` — pccx 생태계의 릴리스 방향 요약
+- {doc}`../v002/index` — 공유 NPU substrate (활성 LLM 라인)
+- {doc}`../v003/index` — LLM 라인 후속, 별도 RTL 저장소


### PR DESCRIPTION
> Re-files [#40](https://github.com/pccxai/pccx/pull/40), which was auto-closed when the stacked base branch was deleted at PR #39 merge. The branch has been rebased onto current `main`; commit content is identical.

## Summary

- Adds placeholder track indices and roadmap entries for the next two release lines, both built on the existing KV260 W4A8 NPU substrate:
  - **v003** — LLM line continued on a separate RTL repository. Working name `pccx-LLM-v003`. First model focus Gemma 4 E4B + one architectural novelty per release point.
  - **vision-v001** — parallel CNN inference track on the same KV260 substrate. Working name `pccx-vision-v001`. First model candidates ResNet18 / YOLOv8n / MobileNetV3 (smallest-footprint variants first).
- Both pages are placeholders; layer-status tables list every layer as TBD.
- The vision-v001 page includes a landscape-context differentiation matrix versus commodity DPU IP and streaming-dataflow QAT toolchains. No FPS / mAP / power figure is claimed; the release evidence checklist remains the wording gate.

## Diagram

`_static/diagrams/pccx_family_tree.svg` — hand-crafted, fixed hex palette, native \`<title>\` tooltips on every node. Identical in light / dark themes; no script dependency.

## Wording posture

All new content is evidence-gated. References to existing vendor / QAT IPs in the vision-v001 differentiation matrix are landscape context only and do not constitute a benchmark.

## Test plan

- [x] \`make strict\` — EN + KO build succeeded (verified before the original push).
- [x] \`sphinx-lint --enable all\` — No problems found.
- [x] \`codespell\` — clean.
- [x] Extended forbidden-token grep across the diff returns empty.
- [ ] Reviewer eyeball: family-tree SVG renders identically under light and dark themes; node hover shows the native tooltip in browser.

## Companion PRs (already merged)

- pccxai/pccx#39 — public wording cleanup.
- pccxai/systemverilog-ide#114, pccxai/pccx-lab#122, pccxai/pccx-llm-launcher#65 — sibling-repo READMEs list the two new working repositories under their related-tracks sections.

## Companion repositories (already created)

- [pccx-LLM-v003](https://github.com/pccxai/pccx-LLM-v003) (public, Apache-2.0)
- [pccx-LLM-v003-staging](https://github.com/pccxai/pccx-LLM-v003-staging) (private)
- [pccx-vision-v001](https://github.com/pccxai/pccx-vision-v001) (public, Apache-2.0)
- [pccx-vision-v001-staging](https://github.com/pccxai/pccx-vision-v001-staging) (private)