### PR TITLE
docs(typography): apply K&R book style — IBM Plex Mono diagrams + Times body

### DIFF
--- a/_static/css/kr-typography.css
+++ b/_static/css/kr-typography.css
@@ -1,0 +1,51 @@
+/*
+ * K&R-inspired typography for the pccx documentation site.
+ *
+ * The body falls back to a serif stack (the same Times-family used in
+ * Kernighan & Ritchie's "The C Programming Language"); code, UI
+ * elements, and all hand-crafted SVG diagrams use IBM Plex Mono with
+ * Courier New as the second-choice fallback. This matches the FigJam
+ * board for the family-tree overview.
+ */
+
+@import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&display=swap");
+
+:root,
+body {
+    --font-stack: "Times New Roman", Times, Georgia, serif;
+    --font-stack--monospace: "IBM Plex Mono", "Courier New",
+        "JetBrains Mono", ui-monospace, Menlo, Consolas, monospace;
+}
+
+/* Furo reads these CSS variables for body and inline-code typography;
+ * the explicit selectors below cover the few places where the theme
+ * does not pick up the variable directly (sidebar nav and the figure
+ * captions that ride on Sphinx's own classes). */
+
+body,
+.sidebar-tree,
+.toctree-wrapper,
+.content {
+    font-family: var(--font-stack);
+}
+
+code,
+pre,
+kbd,
+samp,
+tt,
+.highlight pre,
+.literal-block,
+.code-block,
+.sig {
+    font-family: var(--font-stack--monospace);
+}
+
+/* The repo-name pill, page header, and admonition titles benefit from
+ * the same monospace tone so that the "Last verified against" SHA
+ * boxes read as printed listings rather than UI chrome. */
+.admonition-title,
+.sidebar-brand-text,
+.sig-name {
+    font-family: var(--font-stack--monospace);
+}

--- a/_static/diagrams/pccx_family_tree.svg
+++ b/_static/diagrams/pccx_family_tree.svg
@@ -7,7 +7,7 @@
       <path d="M0,0 L10,5 L0,10 z" fill="#000000"/>
     </marker>
     <style><![CDATA[
-      text { fill: #000000; font: 400 12px ui-sans-serif, system-ui, sans-serif; }
+      text { fill: #000000; font: 400 12px "IBM Plex Mono", "Courier New", "JetBrains Mono", ui-monospace, monospace; }
       .t-title  { font-weight: 600; font-size: 13px; text-anchor: middle; }
       .t-spec   { font-size: 10px; fill: #444444; text-anchor: middle; }
       .t-stage  { font-weight: 600; font-size: 11px; text-anchor: start; }

--- a/_static/diagrams/sample_pe_array.svg
+++ b/_static/diagrams/sample_pe_array.svg
@@ -16,7 +16,7 @@
     <style><![CDATA[
       /* Shared pccx palette: self-contained white canvas, fixed pastel
          block fills, black borders, and black text. */
-      text         { fill: #000000; font: 400 12px ui-sans-serif, system-ui, sans-serif; }
+      text         { fill: #000000; font: 400 12px "IBM Plex Mono", "Courier New", "JetBrains Mono", ui-monospace, monospace; }
       .t-pe        { font-weight: 600; font-size: 13px; text-anchor: middle; }
       .t-axis      { font-size: 10.5px; letter-spacing: 0.02em; }
 

--- a/_static/diagrams/v002_dataflow_sfu.svg
+++ b/_static/diagrams/v002_dataflow_sfu.svg
@@ -6,7 +6,7 @@
       <path d="M0,0 L10,5 L0,10 z" fill="#000000"/>
     </marker>
     <style><![CDATA[
-      text { fill: #000000; font: 400 11px ui-sans-serif, system-ui, sans-serif; }
+      text { fill: #000000; font: 400 11px "IBM Plex Mono", "Courier New", "JetBrains Mono", ui-monospace, monospace; }
       .t-title { font-weight: 600; font-size: 13px; text-anchor: middle; }
       .t-label { font-size: 10px; text-anchor: middle; }
       .block-mem  { fill: #e2efd8; stroke: #000000; stroke-width: 0.8; }

--- a/_static/diagrams/v002_evidence_flow.svg
+++ b/_static/diagrams/v002_evidence_flow.svg
@@ -7,7 +7,7 @@
       <path d="M0,0 L10,5 L0,10 z" fill="#000000"/>
     </marker>
     <style><![CDATA[
-      text { fill: #000000; font: 400 12px ui-sans-serif, system-ui, sans-serif; }
+      text { fill: #000000; font: 400 12px "IBM Plex Mono", "Courier New", "JetBrains Mono", ui-monospace, monospace; }
       .t-title { font-weight: 600; font-size: 13px; text-anchor: middle; }
       .t-spec  { font-size: 10px; fill: #444444; text-anchor: middle; }
 

--- a/_static/diagrams/v002_gemv_reduction.svg
+++ b/_static/diagrams/v002_gemv_reduction.svg
@@ -6,7 +6,7 @@
       <path d="M0,0 L10,5 L0,10 z" fill="#000000"/>
     </marker>
     <style><![CDATA[
-      text { fill: #000000; font: 400 11px ui-sans-serif, system-ui, sans-serif; }
+      text { fill: #000000; font: 400 11px "IBM Plex Mono", "Courier New", "JetBrains Mono", ui-monospace, monospace; }
       .t-title { font-weight: 600; font-size: 13px; text-anchor: middle; }
       .t-label { font-size: 9px; text-anchor: middle; fill: #666666; }
       .block-comp { fill: #ffffff; stroke: #000000; stroke-width: 0.8; }

--- a/_static/diagrams/v002_memory_hierarchy.svg
+++ b/_static/diagrams/v002_memory_hierarchy.svg
@@ -7,7 +7,7 @@
       <path d="M0,0 L10,5 L0,10 z" fill="#000000"/>
     </marker>
     <style><![CDATA[
-      text { fill: #000000; font: 400 12px ui-sans-serif, system-ui, sans-serif; }
+      text { fill: #000000; font: 400 12px "IBM Plex Mono", "Courier New", "JetBrains Mono", ui-monospace, monospace; }
       .t-title { font-weight: 600; font-size: 14px; text-anchor: middle; }
       .t-label { font-size: 11px; text-anchor: middle; }
       .t-spec  { font-size: 10px; fill: #444444; text-anchor: middle; }

--- a/_static/diagrams/v002_shape_const_ram.svg
+++ b/_static/diagrams/v002_shape_const_ram.svg
@@ -7,7 +7,7 @@
       <path d="M0,0 L10,5 L0,10 z" fill="#000000"/>
     </marker>
     <style><![CDATA[
-      text { fill: #000000; font: 400 12px ui-sans-serif, system-ui, sans-serif; }
+      text { fill: #000000; font: 400 12px "IBM Plex Mono", "Courier New", "JetBrains Mono", ui-monospace, monospace; }
       .t-title  { font-weight: 600; font-size: 14px; text-anchor: middle; }
       .t-label  { font-size: 11px; text-anchor: middle; }
       .t-spec   { font-size: 10px; fill: #444444; text-anchor: middle; }

--- a/_static/diagrams/v002_system_context.svg
+++ b/_static/diagrams/v002_system_context.svg
@@ -23,7 +23,7 @@
          fills.  Same appearance in Furo light and dark mode (the
          diagram is a fixed card, not theme-adaptive).  Palette is
          shared across all pccx diagrams. */
-      text          { fill: #000000; font: 400 12px ui-sans-serif, system-ui, sans-serif; }
+      text          { fill: #000000; font: 400 12px "IBM Plex Mono", "Courier New", "JetBrains Mono", ui-monospace, monospace; }
       .t-title      { font-weight: 600; font-size: 13px; }
       .t-sub        { font-size: 11px; }
       .t-axis       { font-size: 10.5px; letter-spacing: 0.02em; }

--- a/conf_common.py
+++ b/conf_common.py
@@ -345,6 +345,7 @@ html_css_files = [
     "custom.css",
     "image-lightbox.css",
     "language-switcher.css",
+    "css/kr-typography.css",
 ]
 html_js_files = [
     "image-lightbox.js",


### PR DESCRIPTION
## Summary

Aligns the documentation site typography with the FigJam family-tree board (now using IBM Plex Mono / Courier New) and the printed-listing tone of K&R's *The C Programming Language*.

- **Body** — falls back to Times New Roman / Times / Georgia (serif).
- **Code, inline code, admonition titles, sidebar brand, signature names** — IBM Plex Mono → Courier New → JetBrains Mono → \`ui-monospace\`. IBM Plex Mono is loaded from Google Fonts.
- **All 8 hand-crafted SVG diagrams** — same monospace stack so they read as printed listings rather than UI chrome.

Hex palettes and figure geometry are unchanged; only the font stack moved.

## Files

- New: \`_static/css/kr-typography.css\` (registered in \`html_css_files\` so it cascades after the legacy \`custom.css\`).
- Modified: \`conf_common.py\` — adds the new stylesheet to the load list.
- Modified: 8 \`_static/diagrams/*.svg\` — font-stack only, no geometry / palette changes.

## Test plan

- [x] \`make strict\` — EN + KO build succeeded.
- [x] \`sphinx-lint --enable all\` — No problems found.
- [x] \`codespell\` — clean.
- [x] Extended forbidden-token grep across the diff returns empty.
- [ ] Reviewer eyeball: body reads in serif, all diagrams + code blocks in IBM Plex Mono. KO pages fall back gracefully where Times Roman has no Hangul coverage.