### PR TITLE
docs(typography): unify body in IBM Plex Mono; add KO auto-translate notice

### DIFF
--- a/_static/css/kr-typography.css
+++ b/_static/css/kr-typography.css
@@ -1,34 +1,46 @@
 /*
- * K&R-inspired typography for the pccx documentation site.
+ * pccx — unified IBM Plex Mono typography.
  *
- * The body falls back to a serif stack (the same Times-family used in
- * Kernighan & Ritchie's "The C Programming Language"); code, UI
- * elements, and all hand-crafted SVG diagrams use IBM Plex Mono with
- * Courier New as the second-choice fallback. This matches the FigJam
- * board for the family-tree overview.
+ * Body, headings, code, UI elements, and all hand-crafted SVG diagrams
+ * share a single IBM Plex Mono stack so the page reads as one coherent
+ * printed listing. The fallback chain prioritises modern monospace
+ * faces (JetBrains Mono, SF Mono, Menlo, Consolas) before reaching
+ * Courier New as a last resort, so environments without IBM Plex Mono
+ * installed still get an evenly weighted glyph rather than the much
+ * wider Courier New.
  */
 
-@import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&display=swap");
 
 :root,
 body {
-    --font-stack: "Times New Roman", Times, Georgia, serif;
-    --font-stack--monospace: "IBM Plex Mono", "Courier New",
-        "JetBrains Mono", ui-monospace, Menlo, Consolas, monospace;
+    --font-stack: "IBM Plex Mono", "JetBrains Mono", "Fira Code",
+        "SF Mono", Menlo, Consolas, ui-monospace, "Courier New",
+        monospace;
+    --font-stack--monospace: "IBM Plex Mono", "JetBrains Mono",
+        "Fira Code", "SF Mono", Menlo, Consolas, ui-monospace,
+        "Courier New", monospace;
 }
 
-/* Furo reads these CSS variables for body and inline-code typography;
- * the explicit selectors below cover the few places where the theme
- * does not pick up the variable directly (sidebar nav and the figure
- * captions that ride on Sphinx's own classes). */
-
+/* Body / headings / paragraphs / list items / table cells — all share
+ * the same monospace stack. Furo reads ``--font-stack`` for its body
+ * text but a few selectors explicitly inherit from the base sans-serif
+ * cascade, so we set them by name. */
 body,
 .sidebar-tree,
 .toctree-wrapper,
-.content {
+.content,
+article,
+h1, h2, h3, h4, h5, h6,
+p, li, td, th, dt, dd,
+.caption, .caption-text,
+.headerlink {
     font-family: var(--font-stack);
 }
 
+/* Code, pre-formatted listings, and the literalinclude blocks pick up
+ * the same stack so SHA admonition contents and the embedded RTL share
+ * the same vertical rhythm as the prose. */
 code,
 pre,
 kbd,
@@ -41,11 +53,35 @@ tt,
     font-family: var(--font-stack--monospace);
 }
 
-/* The repo-name pill, page header, and admonition titles benefit from
- * the same monospace tone so that the "Last verified against" SHA
- * boxes read as printed listings rather than UI chrome. */
+/* Admonition titles, sidebar brand text, and signature names use the
+ * same monospace face as the body so the entire chrome reads as one
+ * surface. */
 .admonition-title,
 .sidebar-brand-text,
 .sig-name {
     font-family: var(--font-stack--monospace);
+}
+
+/* Monospace body text reads denser than proportional faces, so loosen
+ * line-height a notch and cap the readable line length to keep long
+ * paragraphs scannable. */
+body,
+p,
+li,
+dd,
+td {
+    line-height: 1.6;
+}
+
+article p,
+article li,
+article dd {
+    max-width: 78ch;
+}
+
+/* Slightly tighter heading line-height stays inside Furo's vertical
+ * rhythm while picking up the monospace stack. */
+h1, h2, h3, h4, h5, h6 {
+    line-height: 1.3;
+    letter-spacing: -0.005em;
 }

--- a/ko/conf.py
+++ b/ko/conf.py
@@ -58,10 +58,16 @@ exclude_patterns = [
 html_theme_options = {
     **html_theme_options,
     "source_directory": "ko/docs/",
-    # Default announcement is empty — the sidebar's EN · 한국어 switch
-    # handles language.  `_ext.archive_banner` selectively fills this
-    # slot when the reader lands on an archived (non-active) page.
-    "announcement": "",
+    # The Korean tree is produced by external translation tooling; the
+    # English page is the canonical source. ``_ext.archive_banner``
+    # overrides this slot on archived pages with its own redirect, so
+    # the auto-translation notice only appears on active pages.
+    "announcement": (
+        '<strong>Auto-translated.</strong> '
+        'This Korean page is produced by external translation '
+        'tooling; the English page is the source of truth. '
+        '<strong>자동 번역 페이지</strong> — 영문판이 정본입니다.'
+    ),
     "footer_icons": build_footer_icons("ko"),
 }
 


### PR DESCRIPTION
## Summary

Two related changes that align the docs site with the FigJam family-tree board (now in IBM Plex Mono) and with an English-first content posture.

### 1. Body now in IBM Plex Mono (was Times New Roman)

- Body, headings, paragraphs, list items, table cells, code, and the eight hand-crafted SVG diagrams all share a single IBM Plex Mono stack.
- Fallback chain prioritises modern monospace faces (JetBrains Mono → SF Mono → Menlo → Consolas) before reaching Courier New, so environments without IBM Plex Mono get an evenly weighted glyph rather than the much wider Courier New.
- Line-height loosened to 1.6 and paragraph max-width capped at 78ch so monospace prose stays scannable.

### 2. KO announcement slot — auto-translate notice

- Active Korean pages now display an announcement: \"Auto-translated. This Korean page is produced by external translation tooling; the English page is the source of truth. 자동 번역 페이지 — 영문판이 정본입니다.\"
- The \`_ext.archive_banner\` extension still overrides the announcement slot on archived pages, so the auto-translate notice only appears on active pages.
- The English announcement slot is unchanged (empty by default).

## Why

- Previous K&R serif body created an unintended split between body and code on the same page; full IBM Plex Mono unification matches the FigJam board and the user's stated typeface preference.
- Korean pages should signal that they are not the canonical source so readers know which version to trust when content drifts.

## Files

- \`_static/css/kr-typography.css\` — unified font stack, fallback chain rewrite, line-height + max-width tweaks.
- \`ko/conf.py\` — \`html_theme_options.announcement\` set on the KO build only.

## Test plan

- [x] \`make strict\` — EN + KO build succeeded.
- [x] \`sphinx-lint --enable all\` — No problems found.
- [x] \`codespell\` — clean.
- [x] Extended forbidden-token grep across the diff returns empty.
- [ ] Reviewer eyeball: body and code share the same vertical rhythm; KO pages show the auto-translate notice on active pages but not on archived ones; long paragraphs do not overflow 78ch on a wide viewport.