### PR TITLE
docs: split body sans-serif from code mono; dismissable KO banner

### DIFF
--- a/_static/auto-translate-dismiss.js
+++ b/_static/auto-translate-dismiss.js
@@ -1,0 +1,90 @@
+// pccx — Korean auto-translate banner: dismiss + persist.
+//
+// Adds an X close button and a "Don't show again" checkbox to the
+// Furo announcement bar on Korean pages. Dismiss state lives in
+// localStorage under a versioned key so a future banner copy
+// rollover can re-introduce the notice without colliding with old
+// dismiss state.
+//
+// Path-scoped to /ko/ so the banner controls never appear on the
+// English tree even if the announcement slot is non-empty.
+
+(function () {
+    "use strict";
+
+    if (window.location.pathname.indexOf("/ko/") === -1) {
+        return;
+    }
+
+    var STORAGE_KEY = "pccx-auto-translate-banner-hidden-v1";
+
+    function readDismissed() {
+        try {
+            return window.localStorage &&
+                localStorage.getItem(STORAGE_KEY) === "1";
+        } catch (e) {
+            return false;
+        }
+    }
+
+    function writeDismissed() {
+        try {
+            window.localStorage &&
+                localStorage.setItem(STORAGE_KEY, "1");
+        } catch (e) {
+            // localStorage can be unavailable in private-browsing
+            // contexts; the banner just falls back to one-time
+            // dismiss in that session.
+        }
+    }
+
+    if (readDismissed()) {
+        // Hide before first paint to avoid a flash of the banner.
+        var hideStyle = document.createElement("style");
+        hideStyle.textContent =
+            ".announcement { display: none !important; }";
+        document.head.appendChild(hideStyle);
+        return;
+    }
+
+    document.addEventListener("DOMContentLoaded", function () {
+        var bar = document.querySelector(".announcement");
+        if (!bar) {
+            return;
+        }
+
+        var inner = bar.querySelector(".announcement-content") || bar;
+
+        var label = document.createElement("label");
+        label.className = "pccx-banner-dont-show";
+        var checkbox = document.createElement("input");
+        checkbox.type = "checkbox";
+        var labelText = document.createElement("span");
+        labelText.textContent = "Don't show again · 다시 보지 않기";
+        label.appendChild(checkbox);
+        label.appendChild(labelText);
+
+        checkbox.addEventListener("change", function () {
+            if (checkbox.checked) {
+                writeDismissed();
+                bar.style.display = "none";
+            }
+        });
+
+        var closeBtn = document.createElement("button");
+        closeBtn.type = "button";
+        closeBtn.className = "pccx-banner-close";
+        closeBtn.setAttribute(
+            "aria-label",
+            "Dismiss this banner · 이 배너 닫기"
+        );
+        closeBtn.textContent = "✕";
+
+        closeBtn.addEventListener("click", function () {
+            bar.style.display = "none";
+        });
+
+        inner.appendChild(label);
+        inner.appendChild(closeBtn);
+    });
+})();

--- a/_static/css/kr-typography.css
+++ b/_static/css/kr-typography.css
@@ -1,31 +1,31 @@
 /*
- * pccx — unified IBM Plex Mono typography.
+ * pccx — typography + auto-translate banner controls.
  *
- * Body, headings, code, UI elements, and all hand-crafted SVG diagrams
- * share a single IBM Plex Mono stack so the page reads as one coherent
- * printed listing. The fallback chain prioritises modern monospace
- * faces (JetBrains Mono, SF Mono, Menlo, Consolas) before reaching
- * Courier New as a last resort, so environments without IBM Plex Mono
- * installed still get an evenly weighted glyph rather than the much
- * wider Courier New.
+ * Body uses IBM Plex Sans for prose readability; code, signatures,
+ * and the eight hand-crafted SVG diagrams stay in IBM Plex Mono so
+ * the printed-listing tone is preserved where it earns its keep
+ * (instructions, hex addresses, RTL excerpts) without dragging long
+ * paragraphs through monospace.
+ *
+ * Both faces ship from the same family ("IBM Plex") to keep the
+ * page tonally coherent. Modern monospace fallbacks (JetBrains Mono,
+ * SF Mono, Menlo, Consolas) come before Courier New so unfontified
+ * environments still get an evenly weighted glyph.
  */
 
-@import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap");
 
 :root,
 body {
-    --font-stack: "IBM Plex Mono", "JetBrains Mono", "Fira Code",
-        "SF Mono", Menlo, Consolas, ui-monospace, "Courier New",
-        monospace;
+    --font-stack: "IBM Plex Sans", -apple-system, BlinkMacSystemFont,
+        "Segoe UI", Roboto, "Helvetica Neue", Helvetica, Arial,
+        sans-serif;
     --font-stack--monospace: "IBM Plex Mono", "JetBrains Mono",
         "Fira Code", "SF Mono", Menlo, Consolas, ui-monospace,
         "Courier New", monospace;
 }
 
-/* Body / headings / paragraphs / list items / table cells — all share
- * the same monospace stack. Furo reads ``--font-stack`` for its body
- * text but a few selectors explicitly inherit from the base sans-serif
- * cascade, so we set them by name. */
+/* Body, headings, prose blocks — IBM Plex Sans. */
 body,
 .sidebar-tree,
 .toctree-wrapper,
@@ -38,9 +38,7 @@ p, li, td, th, dt, dd,
     font-family: var(--font-stack);
 }
 
-/* Code, pre-formatted listings, and the literalinclude blocks pick up
- * the same stack so SHA admonition contents and the embedded RTL share
- * the same vertical rhythm as the prose. */
+/* Code, pre-formatted listings, signatures — IBM Plex Mono. */
 code,
 pre,
 kbd,
@@ -49,39 +47,83 @@ tt,
 .highlight pre,
 .literal-block,
 .code-block,
-.sig {
-    font-family: var(--font-stack--monospace);
-}
-
-/* Admonition titles, sidebar brand text, and signature names use the
- * same monospace face as the body so the entire chrome reads as one
- * surface. */
-.admonition-title,
-.sidebar-brand-text,
+.sig,
 .sig-name {
     font-family: var(--font-stack--monospace);
 }
 
-/* Monospace body text reads denser than proportional faces, so loosen
- * line-height a notch and cap the readable line length to keep long
- * paragraphs scannable. */
+/* Admonition titles and sidebar brand stay in mono so the chrome
+ * hints "this is a printed listing on top of a written document". */
+.admonition-title,
+.sidebar-brand-text {
+    font-family: var(--font-stack--monospace);
+}
+
+/* Reading geometry for the body face. */
 body,
 p,
 li,
 dd,
 td {
-    line-height: 1.6;
+    line-height: 1.55;
 }
 
 article p,
 article li,
 article dd {
-    max-width: 78ch;
+    max-width: 72ch;
 }
 
-/* Slightly tighter heading line-height stays inside Furo's vertical
- * rhythm while picking up the monospace stack. */
 h1, h2, h3, h4, h5, h6 {
     line-height: 1.3;
     letter-spacing: -0.005em;
+}
+
+/*
+ * Auto-translate banner dismiss controls — the JavaScript that
+ * accompanies these styles only runs on Korean pages and inserts an
+ * "X" close button and a "Don't show again" checkbox into Furo's
+ * announcement bar. Both controls degrade gracefully if JavaScript
+ * is disabled (the bar simply stays visible).
+ */
+.announcement-content {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.6em;
+}
+
+.pccx-banner-dont-show {
+    cursor: pointer;
+    font-size: 0.85em;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3em;
+    user-select: none;
+}
+
+.pccx-banner-dont-show input {
+    margin: 0;
+}
+
+.pccx-banner-close {
+    background: none;
+    border: 1px solid currentColor;
+    border-radius: 3px;
+    color: inherit;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 0.85em;
+    padding: 0.05em 0.45em;
+    margin-left: auto;
+    line-height: 1;
+}
+
+.pccx-banner-close:hover {
+    opacity: 0.75;
+}
+
+.pccx-banner-close:focus-visible {
+    outline: 2px solid currentColor;
+    outline-offset: 1px;
 }

--- a/conf_common.py
+++ b/conf_common.py
@@ -350,6 +350,7 @@ html_css_files = [
 html_js_files = [
     "image-lightbox.js",
     "language-switcher.js",
+    "auto-translate-dismiss.js",
 ]
 
 html_show_sphinx = False


### PR DESCRIPTION
## Summary

Two readability changes that respond to the previous all-mono pass.

### 1. Body sans-serif, code stays mono

- **Body** (paragraphs, headings, list items, table cells, sidebar nav) — IBM Plex Sans → system sans fallbacks. Drops Times Roman entirely.
- **Code** (\`<code>\`, \`<pre>\`, signatures, admonition titles, sidebar brand) — IBM Plex Mono → JetBrains Mono → SF Mono → Menlo → Consolas → Courier New. Modern fallbacks first; Courier New only as a last resort.
- **SVG diagrams** — unchanged; remain in IBM Plex Mono so the family-tree, evidence flow, dispatcher diagrams keep their printed-listing tone.
- Both faces ship from the same family (IBM Plex Sans + IBM Plex Mono), preserving tonal coherence.
- Body line-height 1.55; prose width capped at 72ch.

### 2. KO banner — dismissable + persist

- New \`_static/auto-translate-dismiss.js\`. Path-scoped to \`/ko/\` so it never runs on the English tree.
- Two controls injected into Furo's announcement bar:
  - **\"X\" close button** (\`✕\`) — dismisses the banner for the current page only.
  - **\"Don't show again · 다시 보지 않기\" checkbox** — writes \`pccx-auto-translate-banner-hidden-v1\` to \`localStorage\` and hides the bar across navigation and reloads.
- Versioned localStorage key so future banner copy can re-introduce the notice without colliding with old dismiss state.
- Hides before first paint when the persistent flag is set, so there is no flash of the banner.
- Graceful degradation: when JavaScript is disabled, both controls simply do not appear and the banner stays visible.

## Files

- \`_static/css/kr-typography.css\` — body sans stack, banner control styles, prose width cap.
- \`_static/auto-translate-dismiss.js\` (new) — dismiss + persist logic.
- \`conf_common.py\` — registers the new JS in \`html_js_files\`.

## Test plan

- [x] \`make strict\` — EN + KO build succeeded.
- [x] \`sphinx-lint --enable all\` — No problems found.
- [x] \`codespell\` — clean.
- [x] Extended forbidden-token grep across the diff returns empty.
- [ ] Reviewer eyeball: body reads in sans, code blocks and SHA admonition contents in mono; \"X\" closes the banner for one page, checkbox persists across reloads.

## Related

- KO banner copy was added in #44; this PR only changes its presentation.
- Future infra note: docs hosting is moving to Cloudflare; Sphinx HTML output and the Google Fonts CDN load are already compatible — no change needed in this PR.