### PR TITLE
docs(roadmap): v002.1 progress snapshot

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -47,6 +47,33 @@ Tracking issue: [pccxai/pccx#28 — v0.2.0 umbrella][v020].
 - compute budget for EAGLE head training: $70–100 ($40 if a TRC TPU
   grant lands)
 
+### v002.1 ramp snapshot — 2026-05-06
+
+v002.1 is in progress and remains evidence-gated: public roadmap wording
+tracks reviewable PR evidence, not hardware signoff. The current ramp is
+split across four active RTL / SW lanes:
+
+- `pccx-FPGA-NPU-LLM-kv260`: specification cleanup, bitstream preparation
+  support, xsim coverage, GEMM / GEMV datapath checks, status wiring, and
+  synthesis-baseline capture are represented by
+  [#80](https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/pull/80)–
+  [#89](https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/pull/89).
+- `pccx-llm-launcher`: the KV260 pre-flight scaffold, serial / mock
+  backends, UI integration, and weight-prep manifest work are represented
+  by [#70](https://github.com/pccxai/pccx-llm-launcher/pull/70)–
+  [#74](https://github.com/pccxai/pccx-llm-launcher/pull/74).
+- `pccx-lab`: trace readback, smoke fixtures, serial framing, and analyzer
+  summaries are represented by
+  [#160](https://github.com/pccxai/pccx-lab/pull/160)–
+  [#164](https://github.com/pccxai/pccx-lab/pull/164).
+- `systemverilog-ide`: status-surface, UI integration, and live pre-flight
+  binding work are represented by
+  [#124](https://github.com/pccxai/systemverilog-ide/pull/124)–
+  [#126](https://github.com/pccxai/systemverilog-ide/pull/126).
+
+The public homepage import is tracked separately in
+[`pccxai/pccxai#4`](https://github.com/pccxai/pccxai/pull/4).
+
 ## Later — v003.x: separate RTL repository (LLM line continued)
 
 - v003+ active RTL development moves to a dedicated repository, working


### PR DESCRIPTION
## Summary
- add a short dated v002.1 ramp snapshot to the public roadmap
- group the active RTL/SW lane PR evidence across KV260 RTL, launcher, lab, and SystemVerilog IDE
- include the pccxai homepage import reference

## Claim guard
- v002.1 is described as in progress and evidence-gated
- wording uses 20 tok/s target, bitstream preparation, and pre-flight scaffold
- no hardware signoff, throughput, release, or readiness claim is made
- GitHub evidence showed the referenced PRs as open at snapshot time, so the roadmap says they are represented/tracked rather than landed

## Validation
- `env PATH=/home/hwkim/Desktop/github/pccxai/pccx/.venv/bin:$PATH make strict`
- `env PATH=/home/hwkim/Desktop/github/pccxai/pccx/.venv/bin:$PATH make lint`
- public forbidden-phrase guard scan passed