### PR TITLE
docs: link v002.1 architecture, evidence, runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ issues are welcome.
 
 ---
 
+## v002.1 evidence-gated pointers
+
+| Item | Link | Guard |
+| --- | --- | --- |
+| Architecture explainer | [`docs/spec/v002.1-architecture-explainer.md` (PR #48)](https://github.com/pccxai/pccx/blob/docs/v002.1-architecture-explainer/docs/spec/v002.1-architecture-explainer.md) | Draft explainer; no board-run, closed-timing, deployable-bitstream, or measured-throughput claim. |
+| Evidence inventory | [`pccx-FPGA-NPU-LLM-kv260` evidence inventory (PR #95)](https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/blob/docs/v002.1-evidence-inventory/docs/evidence/v002.1-evidence-inventory.md) | Inventory of landed and pending evidence; release claims remain gated by measured artifacts. |
+| Bitstream runbook | [`pccx-FPGA-NPU-LLM-kv260` bitstream runbook (PR #82)](https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/blob/build/v002-kv260-bitstream-runbook/docs/runbooks/v002.1-bitstream-build.md) | Pre-flight runbook; Vivado and KV260 board execution are not claimed by this link. |
+| Project board | [PCCX Roadmap project board](https://github.com/orgs/pccxai/projects/1) | Planning tracker; status must be read with the evidence gates above. |
+
+---
+
 ## What is pccx?
 
 pccx is a hardware-software co-design framework that accelerates **autoregressive decoding** of Transformer-based LLMs on resource-constrained edge devices. The primary target is the **Xilinx Kria KV260** SOM.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -102,6 +102,32 @@ Working tracks for the next release lines:
 The :doc:`roadmap` summarises how the three tracks relate, and the
 ``pccx`` family-tree figure on that page links them visually.
 
+Evidence-gated v002.1 pointers:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 24 44 32
+
+   * - Item
+     - Link
+     - Guard
+   * - Architecture explainer
+     - `docs/spec/v002.1-architecture-explainer.md (PR #48) <https://github.com/pccxai/pccx/blob/docs/v002.1-architecture-explainer/docs/spec/v002.1-architecture-explainer.md>`__
+     - Draft explainer; no board-run, closed-timing, deployable-bitstream,
+       or measured-throughput claim.
+   * - Evidence inventory
+     - `pccx-FPGA-NPU-LLM-kv260 evidence inventory (PR #95) <https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/blob/docs/v002.1-evidence-inventory/docs/evidence/v002.1-evidence-inventory.md>`__
+     - Inventory of landed and pending evidence; release claims remain
+       gated by measured artifacts.
+   * - Bitstream runbook
+     - `pccx-FPGA-NPU-LLM-kv260 bitstream runbook (PR #82) <https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260/blob/build/v002-kv260-bitstream-runbook/docs/runbooks/v002.1-bitstream-build.md>`__
+     - Pre-flight runbook; Vivado and KV260 board execution are not
+       claimed by this link.
+   * - Project board
+     - `PCCX Roadmap project board <https://github.com/orgs/pccxai/projects/1>`__
+     - Planning tracker; status must be read with the evidence gates
+       above.
+
 The v001 architecture is archived at
 :doc:`archive/experimental_v001/index`.
 


### PR DESCRIPTION
## Summary
- Add evidence-gated v002.1 pointer tables to README.md and docs/index.rst.
- Link the architecture explainer draft from pccx PR #48, the RTL evidence inventory from pccx-FPGA-NPU-LLM-kv260 PR #95, the bitstream runbook from PR #82, and the public project board.
- Keep status language limited to draft, inventory, pre-flight, and planning states.

## Validation
- git diff --check
- env PATH=/home/hwkim/Desktop/github/pccxai/pccx/.venv/bin:$PATH make lint
- env PATH=/home/hwkim/Desktop/github/pccxai/pccx/.venv/bin:$PATH make strict
- rg -n "KV260 inference works|Gemma 3N E4B runs on KV260|20 tok/s achieved|timing closed|bitstream ready|production-ready|stable release" README.md docs/index.rst returned no matches

## Claim guard
This is link-only documentation. It does not claim KV260 inference, Gemma 3N E4B hardware execution, timing closure, bitstream availability/readiness, achieved throughput, production readiness, or stable release status.

Refs pccxai/pccx#48
Refs pccxai/pccx-FPGA-NPU-LLM-kv260#95
Refs pccxai/pccx-FPGA-NPU-LLM-kv260#82