### PR TITLE
docs(contrib): contributors acknowledgements page

### DIFF
--- a/docs/contributors.md
+++ b/docs/contributors.md
@@ -1,0 +1,25 @@
+# Contributors
+
+This page is reserved for acknowledging people who contribute to pccx.
+
+## Acknowledgements
+
+No contributors are listed yet.
+
+## How to Be Acknowledged
+
+Contributors may be acknowledged here after a merged contribution to the
+project, including documentation improvements, issue triage, review feedback,
+reproducible bug reports, examples, diagrams, or code in a related pccx
+repository.
+
+To request acknowledgement, include the following in the pull request or issue:
+
+- Preferred display name.
+- Optional GitHub handle or public profile link.
+- Short description of the contribution.
+- Confirmation that the name or handle may be published on this site.
+
+Maintainers may edit entries for consistency, defer acknowledgement until the
+related work is merged, or remove an entry on request. Automated tooling and bot
+accounts are not listed as contributors.

--- a/index.rst
+++ b/index.rst
@@ -110,6 +110,7 @@ Tooling & Lab
 
    docs/index
    docs/quickstart
+   docs/contributors
    docs/Evidence/index
    docs/roadmap
 


### PR DESCRIPTION
## Summary
- add a placeholder contributors acknowledgements page
- document how contributors can request acknowledgement
- link the page from the Introduction toctree

## Tests
- make strict SPHINXBUILD=.venv/bin/sphinx-build
- env PATH="/tmp/pccx-contrib-wt/.venv/bin:$PATH" make lint