### PR TITLE
docs(index): refresh sphinx index

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -85,10 +85,12 @@ pccx balances efficiency with accuracy:
 Detailed technical specifications for the active **v002** line live
 under :doc:`v002/index`:
 
-1. :doc:`v002/ISA/index` — 64-bit custom instruction set.
-2. :doc:`v002/Architecture/index` — hardware architecture and
+1. :doc:`quickstart` — reader path for release-line claims, evidence,
+   local checks, deploy posture, and common v002.1 questions.
+2. :doc:`v002/ISA/index` — 64-bit custom instruction set.
+3. :doc:`v002/Architecture/index` — hardware architecture and
    floorplan.
-3. :doc:`v002/Drivers/index` — driver and SDK documentation.
+4. :doc:`v002/Drivers/index` — driver and SDK documentation.
 
 Working tracks for the next release lines:
 
@@ -101,6 +103,18 @@ Working tracks for the next release lines:
 
 The :doc:`roadmap` summarises how the three tracks relate, and the
 ``pccx`` family-tree figure on that page links them visually.
+
+New public docs added in the May 7 refresh:
+
+- :doc:`spec/v002.1-architecture-explainer` — evidence-gated v002.1
+  architecture explainer.
+- :doc:`spec/gemma-3n-e4b-path` — Gemma 3N E4B path overview for the
+  v002 line.
+- :doc:`design-decisions` — v002.1 design-decision log.
+- :doc:`contributors` — contributor acknowledgements.
+- :doc:`templates/release-notes-template` — release-notes template for
+  future cuts.
+- :doc:`news/README` — news-section placeholder.
 
 The v001 architecture is archived at
 :doc:`archive/experimental_v001/index`.
@@ -200,5 +214,12 @@ risks, keeping the ecosystem safe for open-source hardware development.
 .. toctree::
    :hidden:
 
+   quickstart
+   spec/v002.1-architecture-explainer
+   spec/gemma-3n-e4b-path
+   design-decisions
+   contributors
+   templates/release-notes-template
+   news/README
    v003/index
    vision-v001/index


### PR DESCRIPTION
## Summary
- Add docs/index.rst links for the May 7 documentation refresh.
- Add hidden toctree entries for the new quickstart, spec, design, contributor, release-template, and news pages.

## Dependencies
- Depends on the referenced page branches landing first: #48, #50, #51, #52, #53, #54.
- Also references docs/news/README.md from docs/news-section-init, which does not currently have an open PR.

## Verification
- git diff --check
- PATH="/tmp/pccx-idxref-wt/.venv/bin:/home/hwkim/.local/bin:/home/hwkim/bin:/home/hwkim/.codex/tmp/arg0/codex-arg0YM7pL1:/home/hwkim/.nvm/versions/node/v24.14.0/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/path:/home/hwkim/.local/bin:/home/hwkim/.local/bin:/home/hwkim/.local/bin:/home/hwkim/.nvm/versions/node/v24.14.0/bin:/tools/Xilinx/2025.2/Model_Composer/bin:/tools/Xilinx/2025.2/Vivado/bin:/tools/Xilinx/2025.2/PDM/bin:/tools/Xilinx/2025.2/Vitis/bin:/tools/Xilinx/2025.2/Vitis/bin:/tools/Xilinx/2025.2/Vitis/gnu/riscv/linux_toolchain/lin32/bin:/tools/Xilinx/2025.2/Vitis/gnu/riscv/linux_toolchain/lin64/bin:/tools/Xilinx/DocNav:/home/hwkim/.cargo/bin:/home/hwkim/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/snap/bin:/home/hwkim/.claude/plugins/cache/claude-plugins-official/rust-analyzer-lsp/1.0.0/bin:/home/hwkim/.claude/plugins/cache/claude-plugins-official/figma/2.1.30/bin" make strict *(expected failure on this branch before dependencies land: missing toctree/doc references for the new pages)*