### PR TITLE
Document PCCX trademark policy and filing docket

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,14 @@ python -m http.server --directory _build/html
 
 Licensed under the **[Apache License 2.0](LICENSE)**.
 
+## Trademark
 
+`PCCX™` is a mark used by the PCCX project. Korean trademark
+applications are pending for PCCX in Classes 09 and 42 (application
+numbers `40-2026-0091497` and `40-2026-0091498`). Registration has
+not been granted; do not use `PCCX®` until this policy is updated.
+See [`TRADEMARKS.md`](TRADEMARKS.md) for permitted use, restricted
+use, and the public-safe filing docket.
 
 <div align="center">
 

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -1,3 +1,7 @@
+---
+orphan: true
+---
+
 # PCCX Trademark Policy
 
 Status: pending trademark applications; not legal advice.

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -1,0 +1,74 @@
+# PCCX Trademark Policy
+
+Status: pending trademark applications; not legal advice.
+
+PCCX™ is a mark used by the PCCX project for an open AI accelerator
+architecture, reusable IP-core packages, tooling, documentation, and
+related commercialization tracks.
+
+## Current filing status
+
+Korean trademark applications have been filed for PCCX:
+
+| Jurisdiction | Class | Application number | Status |
+| --- | --- | --- | --- |
+| KR | 09 | 40-2026-0091497 | Pending application |
+| KR | 42 | 40-2026-0091498 | Pending application |
+
+These are pending applications, not registrations. Do not use
+`PCCX®` unless and until registration is granted and the project
+explicitly updates this policy.
+
+## Permitted truthful use
+
+You may use the PCCX name to truthfully refer to the project, its
+repositories, documentation, compatible tooling, or integrations,
+provided that your use does not imply endorsement, certification,
+partnership, official status, or trademark ownership.
+
+## Restricted use
+
+Do not use PCCX marks in a way that implies any of:
+
+- official certification;
+- compatibility approval;
+- endorsement;
+- partnership;
+- ownership by your project or company;
+- investment solicitation;
+- financial return;
+- contributor revenue share.
+
+## Certification and compatibility badges
+
+`PCCX Compatible`, `PCCX Certified`, and related badge language are
+reserved for a future conformance/certification program. Do not use
+those terms as official claims until a published conformance process
+exists and written approval is granted.
+
+## Commercial / IP boundary
+
+Sponsorship is not investment. Contributions do not create rights to
+equity, royalties, revenue share, profit share, employment,
+sponsorship payments, or investor returns. Investment, if any, is
+handled separately under written agreements and applicable law. See
+`docs/commercial/` and `docs/ip/` for the layered draft policy.
+
+## Foreign priority docket
+
+Internal Madrid / foreign filing safety deadline: 2026-11-06.
+
+This policy does not publish private filing records, customer
+numbers, payment receipts, addresses, or personal contact details.
+
+## Layered policy
+
+This page is the canonical entry point. The IP layers (patent
+strategy, trade secret, contributor licence) and the commercial
+tracks (open / commercial / capital) are described in:
+
+- [`docs/ip/`](docs/ip/README.md) — IP strategy layers (DRAFT).
+- [`docs/commercial/`](docs/commercial/README.md) — commercialization
+  tracks (DRAFT).
+- [`docs/ip/trademark-filing-log.md`](docs/ip/trademark-filing-log.md)
+  — public-safe filing docket.

--- a/docs/ip/README.md
+++ b/docs/ip/README.md
@@ -20,6 +20,8 @@ and independently governed.
   inventions, classification procedure before disclosure.
 - [Trademarks](trademarks.md) — claimed common-law marks; formal
   registration TBD.
+- [Trademark filing log](trademark-filing-log.md) — public-safe
+  pending-application docket (KR Class 09 / 42).
 - [Trade secret policy](trade-secret-policy.md) — what is treated
   as trade secret and how access is controlled.
 - [Contributor License Agreement (placeholder)](contributor-license-agreement.md)

--- a/docs/ip/trademark-filing-log.md
+++ b/docs/ip/trademark-filing-log.md
@@ -1,0 +1,74 @@
+---
+orphan: true
+---
+
+> Public-safe filing docket. Not legal advice. Subject to qualified
+> legal review before any binding use. Korea first-to-file rule
+> applies; consult a Korean patent attorney before any further
+> public disclosure of candidate inventions.
+
+# PCCX trademark filing log
+
+Public-safe record of trademark filings for the PCCX™ mark. This
+page intentionally excludes private filing materials.
+
+## What this page contains
+
+- The mark
+- The jurisdiction
+- The class
+- The application number
+- The filing date
+- The pending status
+- Internal foreign-filing safety deadline
+
+## What this page does not contain
+
+- 특허고객번호 (applicant customer number)
+- Original XML filings
+- Payment receipts
+- Applicant private contact details
+- Screenshots that would expose personal data
+
+Those records are kept under separate confidentiality controls and do
+not enter this repository.
+
+## Korean filings
+
+| Class | Application number | Filing date | Status |
+| --- | --- | --- | --- |
+| 09 | 40-2026-0091497 | 2026-05-08 | Pending application |
+| 42 | 40-2026-0091498 | 2026-05-08 | Pending application |
+
+Class 09 and Class 42 cover, respectively, the goods and services
+relevant to the open and commercial PCCX tracks. The applications
+are pending; **registration has not been granted**.
+
+## Foreign priority window
+
+| Item | Date |
+| --- | --- |
+| Korean filing date | 2026-05-08 |
+| Internal Madrid / foreign-filing safety deadline | 2026-11-06 |
+
+Foreign filings (Madrid, US, EU, JP, CN, UK, SG, or a subset) are a
+separate decision, gated on the Korean priority window above. The
+target jurisdictions and the corresponding fees are TBD; see the
+trademark docket issue in `pccxai/pccx` for the working list.
+
+## Use guideline summary
+
+- Use `PCCX™` on first prominent mention in any new public-facing
+  document.
+- Do not use `PCCX®`, `registered trademark`, or `등록상표` until
+  registration is granted in the relevant jurisdiction and this
+  policy is explicitly updated.
+- Treat `PCCX Compatible` and `PCCX Certified` as future
+  certification terms only; do not present them as live official
+  badges.
+
+## Linked
+
+- Central trademark policy: [`TRADEMARKS.md`](../../TRADEMARKS.md)
+- IP strategy: [`docs/ip/`](README.md)
+- Commercial tracks: [`docs/commercial/`](../commercial/README.md)

--- a/docs/ip/trademarks.md
+++ b/docs/ip/trademarks.md
@@ -14,6 +14,12 @@ The project claims common-law rights in the marks below through
 ongoing public use. Formal registration is TBD; the marks listed
 here are claims of use, not statements of registration.
 
+For the canonical entry point and the live filing docket, see
+[`TRADEMARKS.md`](../../TRADEMARKS.md) (root) and
+[`trademark-filing-log.md`](trademark-filing-log.md) (this directory).
+Use `PCCX™` on first prominent mention; do not use `PCCX®` until
+registration is granted in the relevant jurisdiction.
+
 ## Claimed marks
 
 | Mark | Use |

--- a/ko/docs/ip/trademark-filing-log.md
+++ b/ko/docs/ip/trademark-filing-log.md
@@ -1,0 +1,10 @@
+---
+orphan: true
+---
+
+# (자동 번역 대기)
+
+이 페이지는 영문판이 정본입니다. 자동 번역 도구가 채울 자리이며,
+신규 본문을 한국어로 직접 작성하지 마세요.
+
+영문 원본: `docs/ip/trademark-filing-log.md` — <https://github.com/pccxai/pccx/blob/main/docs/ip/trademark-filing-log.md>


### PR DESCRIPTION
Adds the canonical PCCX trademark policy and a public-safe filing
docket to the docs source-of-truth repo.

Adds
- `TRADEMARKS.md` (root) — pending KR Class 09 / 42 applications,
  permitted truthful use, restricted use, certification badge
  reservation, commercial / IP boundary, foreign priority window.
- `docs/ip/trademark-filing-log.md` — public-safe pending-application
  docket. Application numbers, classes, filing date, status. No
  customer numbers, XML, payment receipts, addresses, or personal
  contact details.
- `ko/docs/ip/trademark-filing-log.md` — KO mirror stub
  (auto-translation slot, EN canonical).
- `docs/ip/README.md` — link to the new filing log.
- `docs/ip/trademarks.md` — cross-link to the canonical
  `TRADEMARKS.md` and the filing log.
- `README.md` — public-safe trademark notice with the same pending
  status wording.

Status
- These are pending applications, **not** registrations.
- This PR does **not** use `PCCX®`, does **not** claim
  registration, and does **not** include private filing materials.
- The public docs continue to use `PCCX™` on first prominent
  mention.

Verification
- Word-boundary banned-token grep across the diff: clean
  (no `PCCX®`, `registered trademark`, `등록상표`,
  `상표등록완료`, `officially registered`).
- Disclaimer marker present on every IP / commercial doc touched.

Linked
- Tracking issue: pccxai/pccx#61
- Phase V continuation report (in flight)
