### PR TITLE
Add PCCX source headers and SPDX notices

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,3 +1,7 @@
+# PCCX(TM) — reusable AI accelerator project.
+# SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+# SPDX-License-Identifier: Apache-2.0
+
 name: Sphinx Pages
 
 on:

--- a/.github/workflows/en-ko-sync.yml
+++ b/.github/workflows/en-ko-sync.yml
@@ -1,3 +1,7 @@
+# PCCX(TM) — reusable AI accelerator project.
+# SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+# SPDX-License-Identifier: Apache-2.0
+
 name: EN / KO doc set
 
 on:

--- a/.github/workflows/isa-pdf.yml
+++ b/.github/workflows/isa-pdf.yml
@@ -1,3 +1,7 @@
+# PCCX(TM) — reusable AI accelerator project.
+# SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+# SPDX-License-Identifier: Apache-2.0
+
 name: isa-pdf
 
 # Build the ISA guidebook (main.tex) on every change to the LaTeX source

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,3 +1,7 @@
+# PCCX(TM) — reusable AI accelerator project.
+# SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+# SPDX-License-Identifier: Apache-2.0
+
 name: Docs lint
 
 on:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,3 +1,7 @@
+# PCCX(TM) — reusable AI accelerator project.
+# SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+# SPDX-License-Identifier: Apache-2.0
+
 name: repo-validate
 
 # Lightweight always-run gate. Fast, decisive, no external installs.

--- a/_ext/__init__.py
+++ b/_ext/__init__.py
@@ -1,1 +1,5 @@
+# PCCX(TM) — reusable AI accelerator project.
+# SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+# SPDX-License-Identifier: Apache-2.0
+
 """Local Sphinx extensions for pccx."""

--- a/_ext/archive_banner.py
+++ b/_ext/archive_banner.py
@@ -1,3 +1,7 @@
+# PCCX(TM) — reusable AI accelerator project.
+# SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+# SPDX-License-Identifier: Apache-2.0
+
 """
 pccx — archive → latest redirect banner.
 

--- a/_ext/pccx_diagrams.py
+++ b/_ext/pccx_diagrams.py
@@ -1,3 +1,7 @@
+# PCCX(TM) — reusable AI accelerator project.
+# SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+# SPDX-License-Identifier: Apache-2.0
+
 """
 pccx — Deterministic Architecture Diagram Generator.
 

--- a/_ext/rtl_source.py
+++ b/_ext/rtl_source.py
@@ -1,3 +1,7 @@
+# PCCX(TM) — reusable AI accelerator project.
+# SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+# SPDX-License-Identifier: Apache-2.0
+
 """
 pccx — RTL source link injector.
 

--- a/_ext/schema_org.py
+++ b/_ext/schema_org.py
@@ -1,3 +1,7 @@
+# PCCX(TM) — reusable AI accelerator project.
+# SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+# SPDX-License-Identifier: Apache-2.0
+
 """
 pccx — Schema.org JSON-LD injector.
 

--- a/_static/ISA_Instruction_set_architecture.html
+++ b/_static/ISA_Instruction_set_architecture.html
@@ -1,3 +1,9 @@
+<!--
+PCCX™ — reusable AI accelerator project.
+SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+SPDX-License-Identifier: Apache-2.0
+-->
+
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <style type="text/css">
     .ritz .waffle a {

--- a/_static/auto-translate-dismiss.js
+++ b/_static/auto-translate-dismiss.js
@@ -1,3 +1,7 @@
+// PCCX(TM) — reusable AI accelerator project.
+// SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+// SPDX-License-Identifier: Apache-2.0
+
 // pccx — Korean auto-translate banner: dismiss + persist.
 //
 // Adds an X close button and a "Don't show again" checkbox to the

--- a/_static/css/kr-typography.css
+++ b/_static/css/kr-typography.css
@@ -1,4 +1,10 @@
 /*
+PCCX™ — reusable AI accelerator project.
+SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+SPDX-License-Identifier: Apache-2.0
+*/
+
+/*
  * pccx — typography + auto-translate banner controls.
  *
  * Body uses IBM Plex Sans for prose readability; code, signatures,

--- a/_static/custom.css
+++ b/_static/custom.css
@@ -1,3 +1,9 @@
+/*
+PCCX™ — reusable AI accelerator project.
+SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+SPDX-License-Identifier: Apache-2.0
+*/
+
 /* =============================================================================
  * pccx — Furo theme overrides
  *

--- a/_static/diagrams/pccx_family_tree.svg
+++ b/_static/diagrams/pccx_family_tree.svg
@@ -1,4 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+PCCX™ — reusable AI accelerator project.
+SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+SPDX-License-Identifier: Apache-2.0
+-->
+
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 460" role="img">
   <title>pccx product family tree — versions and tracks</title>
 

--- a/_static/diagrams/sample_pe_array.svg
+++ b/_static/diagrams/sample_pe_array.svg
@@ -1,4 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+PCCX™ — reusable AI accelerator project.
+SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+SPDX-License-Identifier: Apache-2.0
+-->
+
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 560 360" role="img"
      aria-labelledby="title-sample-pe desc-sample-pe">
   <title id="title-sample-pe">4×4 PE array — weight-stationary dataflow</title>

--- a/_static/diagrams/v002_dataflow_sfu.svg
+++ b/_static/diagrams/v002_dataflow_sfu.svg
@@ -1,4 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+PCCX™ — reusable AI accelerator project.
+SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+SPDX-License-Identifier: Apache-2.0
+-->
+
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 540 320" role="img">
   <title>SFU (CVO) Instruction Dataflow</title>
   <defs>

--- a/_static/diagrams/v002_evidence_flow.svg
+++ b/_static/diagrams/v002_evidence_flow.svg
@@ -1,4 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+PCCX™ — reusable AI accelerator project.
+SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+SPDX-License-Identifier: Apache-2.0
+-->
+
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 200" role="img">
   <title>pccx v002 — release evidence flow (RTL → verification → release gate)</title>
 

--- a/_static/diagrams/v002_gemv_reduction.svg
+++ b/_static/diagrams/v002_gemv_reduction.svg
@@ -1,4 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+PCCX™ — reusable AI accelerator project.
+SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+SPDX-License-Identifier: Apache-2.0
+-->
+
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 540 340" role="img">
   <title>GEMV 32-lane Reduction Tree Architecture</title>
   <defs>

--- a/_static/diagrams/v002_memory_hierarchy.svg
+++ b/_static/diagrams/v002_memory_hierarchy.svg
@@ -1,4 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+PCCX™ — reusable AI accelerator project.
+SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+SPDX-License-Identifier: Apache-2.0
+-->
+
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 420" role="img">
   <title>pccx v002 Memory Hierarchy &amp; Interconnect</title>
   

--- a/_static/diagrams/v002_shape_const_ram.svg
+++ b/_static/diagrams/v002_shape_const_ram.svg
@@ -1,4 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+PCCX™ — reusable AI accelerator project.
+SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+SPDX-License-Identifier: Apache-2.0
+-->
+
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" role="img">
   <title>pccx v002 — shape_const_ram MEMSET write / shape-pointer read paths</title>
 

--- a/_static/diagrams/v002_system_context.svg
+++ b/_static/diagrams/v002_system_context.svg
@@ -1,4 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+PCCX™ — reusable AI accelerator project.
+SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+SPDX-License-Identifier: Apache-2.0
+-->
+
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 560" role="img"
      aria-labelledby="title-sysctx desc-sysctx">
   <title id="title-sysctx">pccx v002 system context on KV260</title>

--- a/_static/image-lightbox.css
+++ b/_static/image-lightbox.css
@@ -1,3 +1,9 @@
+/*
+PCCX™ — reusable AI accelerator project.
+SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+SPDX-License-Identifier: Apache-2.0
+*/
+
 /* Lightweight image lightbox */
 
 .pccx-zoomable {

--- a/_static/image-lightbox.js
+++ b/_static/image-lightbox.js
@@ -1,3 +1,7 @@
+// PCCX(TM) — reusable AI accelerator project.
+// SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+// SPDX-License-Identifier: Apache-2.0
+
 /*
  * Click-to-zoom lightbox for <img> inside content figures.
  *

--- a/_static/language-switcher.css
+++ b/_static/language-switcher.css
@@ -1,3 +1,9 @@
+/*
+PCCX™ — reusable AI accelerator project.
+SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+SPDX-License-Identifier: Apache-2.0
+*/
+
 /* =============================================================================
  * pccx — language switcher (Furo-aware).
  *

--- a/_static/language-switcher.js
+++ b/_static/language-switcher.js
@@ -1,3 +1,7 @@
+// PCCX(TM) — reusable AI accelerator project.
+// SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+// SPDX-License-Identifier: Apache-2.0
+
 /*
  * pccx — language switcher (Furo-aware).
  *

--- a/_static/mermaid-theme.css
+++ b/_static/mermaid-theme.css
@@ -1,3 +1,9 @@
+/*
+PCCX™ — reusable AI accelerator project.
+SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+SPDX-License-Identifier: Apache-2.0
+*/
+
 /* Mermaid container polish — coexists with sphinxcontrib-mermaid's own styles.
  * sphinxcontrib-mermaid wraps diagrams in .mermaid-container and injects a
  * fullscreen button; we tune spacing and dark-mode surface. */

--- a/_static/mermaid-theme.js
+++ b/_static/mermaid-theme.js
@@ -1,3 +1,7 @@
+// PCCX(TM) — reusable AI accelerator project.
+// SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+// SPDX-License-Identifier: Apache-2.0
+
 /**
  * mermaid-theme.js
  * Re-renders Mermaid diagrams whenever PyData Sphinx Theme switches

--- a/_templates/personal-link.html
+++ b/_templates/personal-link.html
@@ -1,3 +1,9 @@
+<!--
+PCCX™ — reusable AI accelerator project.
+SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+SPDX-License-Identifier: Apache-2.0
+-->
+
 <p class="personal-link">
   <a href="https://hkimw.github.io/hkimw/" target="_blank" rel="noopener">
     hkimw.github.io

--- a/_templates/sidebar/brand.html
+++ b/_templates/sidebar/brand.html
@@ -1,3 +1,9 @@
+<!--
+PCCX™ — reusable AI accelerator project.
+SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+SPDX-License-Identifier: Apache-2.0
+-->
+
 {#
  # pccx — Furo sidebar brand slot override.
  #

--- a/conf.py
+++ b/conf.py
@@ -1,3 +1,7 @@
+# PCCX(TM) — reusable AI accelerator project.
+# SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+# SPDX-License-Identifier: Apache-2.0
+
 """
 pccx — English Sphinx configuration.
 

--- a/conf_common.py
+++ b/conf_common.py
@@ -1,3 +1,7 @@
+# PCCX(TM) — reusable AI accelerator project.
+# SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+# SPDX-License-Identifier: Apache-2.0
+
 """
 pccx — shared Sphinx configuration.
 

--- a/docs/archive/experimental_v001/Drivers/ISA_Instruction_set_architecture.html
+++ b/docs/archive/experimental_v001/Drivers/ISA_Instruction_set_architecture.html
@@ -1,3 +1,9 @@
+<!--
+PCCX™ — reusable AI accelerator project.
+SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+SPDX-License-Identifier: Apache-2.0
+-->
+
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <style type="text/css">
     .ritz .waffle a {

--- a/docs/archive/experimental_v001/Drivers/uCA_v1_api.c
+++ b/docs/archive/experimental_v001/Drivers/uCA_v1_api.c
@@ -1,3 +1,7 @@
+// PCCX(TM) — reusable AI accelerator project.
+// SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+// SPDX-License-Identifier: Apache-2.0
+
 // ===| uCA API Implementation |==================================================
 // Builds 64-bit VLIW instructions from structured arguments and issues them
 // to the NPU via the HAL. Encoding per docs/ISA.md.

--- a/docs/archive/experimental_v001/Drivers/uCA_v1_api.h
+++ b/docs/archive/experimental_v001/Drivers/uCA_v1_api.h
@@ -1,3 +1,7 @@
+// PCCX(TM) — reusable AI accelerator project.
+// SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+// SPDX-License-Identifier: Apache-2.0
+
 // ===| uCA API (High-Level Driver Interface) |====================================
 // uCA: micro Compute Architecture — AI model acceleration API for FPGA NPU.
 //

--- a/docs/stylesheets/custom.css
+++ b/docs/stylesheets/custom.css
@@ -1,3 +1,9 @@
+/*
+PCCX™ — reusable AI accelerator project.
+SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+SPDX-License-Identifier: Apache-2.0
+*/
+
 /* uCA Documentation - Android Style Final Fix */
 
 :root {

--- a/docs/v002/Contracts/pccx-v002-contract.yaml
+++ b/docs/v002/Contracts/pccx-v002-contract.yaml
@@ -1,3 +1,7 @@
+# PCCX(TM) — reusable AI accelerator project.
+# SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+# SPDX-License-Identifier: Apache-2.0
+
 arch: pccx-v002
 package_repo: pccx-v002
 domains:

--- a/docs/v003/Contracts/pccx-v003-contract.yaml
+++ b/docs/v003/Contracts/pccx-v003-contract.yaml
@@ -1,3 +1,7 @@
+# PCCX(TM) — reusable AI accelerator project.
+# SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+# SPDX-License-Identifier: Apache-2.0
+
 arch: pccx-v003
 package_repo: pccx-v003
 domains:

--- a/ko/conf.py
+++ b/ko/conf.py
@@ -1,3 +1,7 @@
+# PCCX(TM) — reusable AI accelerator project.
+# SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+# SPDX-License-Identifier: Apache-2.0
+
 """
 pccx — Korean Sphinx configuration.
 

--- a/plots/plot_bandwidth.py
+++ b/plots/plot_bandwidth.py
@@ -1,3 +1,7 @@
+# PCCX(TM) — reusable AI accelerator project.
+# SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Batch size vs achieved HP-AXI bandwidth
 ========================================

--- a/tools/build_isa_pdf.sh
+++ b/tools/build_isa_pdf.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# PCCX(TM) — reusable AI accelerator project.
+# SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+# SPDX-License-Identifier: Apache-2.0
+
 # Build the pccx v002 ISA Guidebook (main.tex) and drop the final PDF
 # where the Furo site can serve it.
 #

--- a/tools/freeze_active.sh
+++ b/tools/freeze_active.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# PCCX(TM) — reusable AI accelerator project.
+# SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # freeze_active.sh — snapshot the currently-active RTL at a tag into
 # pccx/codes/vNNN/ as the permanent archive for that architecture version.

--- a/tools/phase0/download_gemma3n.py
+++ b/tools/phase0/download_gemma3n.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# PCCX(TM) — reusable AI accelerator project.
+# SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+# SPDX-License-Identifier: Apache-2.0
+
 """Pull Gemma 3N E4B weights from HuggingFace into a local cache.
 
 Gated repo: accept the license on

--- a/tools/phase0/prepare_sharegpt.py
+++ b/tools/phase0/prepare_sharegpt.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# PCCX(TM) — reusable AI accelerator project.
+# SPDX-FileCopyrightText: 2026 Hyun Woo Kim
+# SPDX-License-Identifier: Apache-2.0
+
 """Prepare a mixed Korean + English ShareGPT slice for EAGLE-3 training.
 
 Output: parquet with columns `id`, `conversations` (list of {role, content}),


### PR DESCRIPTION
Adds `PCCX(TM)` + `SPDX-FileCopyrightText` + `SPDX-License-Identifier: Apache-2.0` to source files that lack a header. No identifiers/modules/packages renamed; no behavior changes; no `PCCX®` claim; no private filing materials. Generated/vendor/lock/binary files skipped.