### PR TITLE
Add PCCX commercial evidence and data-room templates

### DIFF
--- a/docs/commercial/asickit-roadmap.md
+++ b/docs/commercial/asickit-roadmap.md
@@ -1,0 +1,27 @@
+---
+orphan: true
+---
+
+> Draft operational policy. Not legal advice. Subject to legal, tax,
+> accounting, securities, and IP counsel review before use. Not an
+> offer to sell securities. Not an investment solicitation.
+> Sponsorship is not investment and provides no financial return.
+> Contributions do not create equity, royalties, revenue share,
+> profit share, employment, sponsorship payments, or investor returns.
+
+# PCCX ASICKit roadmap (draft)
+
+ASICKit is a *future* commercial package targeting customers who
+need tape-out-ready deliverables. **No tape-out rights are granted
+by this document.**
+
+Roadmap items:
+- Foundry-targeted RTL views.
+- Timing / PPA scripts.
+- Verification collateral.
+- Tape-out licence terms (separate written agreement).
+
+PCCX™ does not currently ship ASICKit. Layout-design rights apply
+only when an actual ASIC layout exists; see
+`docs/ip/founder-ip-assignment-checklist-public.md` and
+`pccx/IP_POLICY.md`.

--- a/docs/commercial/investor-overview-draft.md
+++ b/docs/commercial/investor-overview-draft.md
@@ -1,0 +1,28 @@
+---
+orphan: true
+---
+
+> Draft operational policy. Not legal advice. Subject to legal, tax,
+> accounting, securities, and IP counsel review before use. Not an
+> offer to sell securities. Not an investment solicitation.
+> Sponsorship is not investment and provides no financial return.
+> Contributions do not create equity, royalties, revenue share,
+> profit share, employment, sponsorship payments, or investor returns.
+
+# Investor overview (draft)
+
+This page is a public-safe overview for parties evaluating an
+*investment relationship* with the PCCX™ project's commercial
+entity. **It is not an offer to sell securities, not investment
+advice, and not a solicitation.**
+
+Any investment, if any:
+- Requires a separate written agreement under applicable corporate
+  and securities law.
+- Is independent of contributor / sponsor / strategic-customer
+  relationships.
+- Does not give the investor automatic rights to commercial-track
+  deliverables outside the agreement.
+
+The PCCX project's primary entity, governance, and capital
+structure live outside this repository.

--- a/docs/commercial/procore-evaluation-kit.md
+++ b/docs/commercial/procore-evaluation-kit.md
@@ -1,0 +1,24 @@
+---
+orphan: true
+---
+
+> Draft operational policy. Not legal advice. Subject to legal, tax,
+> accounting, securities, and IP counsel review before use. Not an
+> offer to sell securities. Not an investment solicitation.
+> Sponsorship is not investment and provides no financial return.
+> Contributions do not create equity, royalties, revenue share,
+> profit share, employment, sponsorship payments, or investor returns.
+
+# PCCX ProCore evaluation kit (draft)
+
+A proposed bundle for hardware integrators evaluating PCCX™ ProCore.
+**Not currently shipped.** No evaluation contract, no NRE, no tape-out
+rights granted by this document.
+
+When the package ships:
+- Evaluation licence: time-bounded, non-production, non-transfer.
+- Deliverables: hardened RTL view, harness, integration notes.
+- Restrictions: no production rights, no tape-out rights, no
+  redistribution.
+
+Pricing and terms are TBD pending qualified counsel review.

--- a/docs/commercial/product-packages.md
+++ b/docs/commercial/product-packages.md
@@ -1,0 +1,29 @@
+---
+orphan: true
+---
+
+> Draft operational policy. Not legal advice. Subject to legal, tax,
+> accounting, securities, and IP counsel review before use. Not an
+> offer to sell securities. Not an investment solicitation.
+> Sponsorship is not investment and provides no financial return.
+> Contributions do not create equity, royalties, revenue share,
+> profit share, employment, sponsorship payments, or investor returns.
+
+# PCCX product packages (draft)
+
+PCCX™ ships in three commercial-track packages alongside the open
+core. None of these packages claim hardware/runtime/timing/bitstream
+evidence; pricing and availability are TBD pending qualified counsel
+review.
+
+| Package | Audience | Scope (intent) |
+| --- | --- | --- |
+| **ProCore** | Hardware integrators | Hardened, integration-tuned RTL bundles built on the v002/v003 OpenCore. Ships under a separate commercial licence. |
+| **Enterprise SDK** | Toolchain customers | Closed compiler backend, runtime extensions, certification harness. |
+| **ASICKit** | Tape-out customers | Tape-out-oriented deliverables: foundry-targeted RTL views, timing scripts, verification collateral. Roadmap. |
+
+The open track (PCCX Standard, ISA, SDK reference, simulator,
+conformance tests, OpenCore reference, docs) remains under the
+existing open licence and is not gated by these commercial packages.
+
+Tracker: pccxai/pccx#61.

--- a/docs/commercial/public-private-roadmap.md
+++ b/docs/commercial/public-private-roadmap.md
@@ -1,0 +1,37 @@
+---
+orphan: true
+---
+
+> Draft operational policy. Not legal advice. Subject to legal, tax,
+> accounting, securities, and IP counsel review before use. Not an
+> offer to sell securities. Not an investment solicitation.
+> Sponsorship is not investment and provides no financial return.
+> Contributions do not create equity, royalties, revenue share,
+> profit share, employment, sponsorship payments, or investor returns.
+
+# Public / private track roadmap (draft)
+
+Public Open Track:
+- PCCX Standard (architecture spec).
+- ISA / profiles.
+- SDK reference / simulator / conformance tests.
+- OpenCore reference RTL.
+- Public docs.
+
+Private Commercial Track:
+- ProCore.
+- Enterprise SDK / compiler backend.
+- ASICKit.
+- Customer model porting.
+- Integration support.
+- Certification.
+
+Capital Track:
+- Sponsors (acknowledgement only, no financial return).
+- Strategic customers (NRE / licence / support, not investment).
+- External investors (separate written investment agreements under
+  applicable law).
+- ASIC SPV / project financing (future).
+
+Roadmap items are *intent and planning markers*, not commitments,
+schedules, or pricing.

--- a/docs/commercial/risk-factors.md
+++ b/docs/commercial/risk-factors.md
@@ -1,0 +1,31 @@
+---
+orphan: true
+---
+
+> Draft operational policy. Not legal advice. Subject to legal, tax,
+> accounting, securities, and IP counsel review before use. Not an
+> offer to sell securities. Not an investment solicitation.
+> Sponsorship is not investment and provides no financial return.
+> Contributions do not create equity, royalties, revenue share,
+> profit share, employment, sponsorship payments, or investor returns.
+
+# Risk factors (draft)
+
+Public-safe risk register for the PCCX™ commercialization tracks.
+This page is **not** a securities filing risk-factor section.
+
+Engineering risks (unchanged from public risk register):
+- Timing closure on KV260 pending.
+- W4A8 golden-vector gate population pending.
+- Submodule pin drift after rebase merges (mitigation documented).
+- Auto-translated KO docs may drift inside matched files.
+- Vivado toolchain version drift.
+
+Adoption / commercial risks:
+- Cloudflare DNS / hosting outage.
+- KIPRIS publication delay.
+- Foreign-filing target jurisdiction selection.
+- Hiring / capacity constraints.
+- Customer pipeline maturity.
+
+No risk on this page implies a guaranteed mitigation.

--- a/docs/commercial/sponsorship-policy.md
+++ b/docs/commercial/sponsorship-policy.md
@@ -1,0 +1,24 @@
+---
+orphan: true
+---
+
+> Draft operational policy. Not legal advice. Subject to legal, tax,
+> accounting, securities, and IP counsel review before use. Not an
+> offer to sell securities. Not an investment solicitation.
+> Sponsorship is not investment and provides no financial return.
+> Contributions do not create equity, royalties, revenue share,
+> profit share, employment, sponsorship payments, or investor returns.
+
+# Sponsorship policy (draft)
+
+Sponsorship of the PCCX™ project is acknowledgement-only.
+
+A sponsor:
+- May be acknowledged on the PCCX project site or in release notes
+  per the published sponsorship policy.
+- Does **not** receive equity, royalties, revenue share, profit
+  share, securities, deliverables under contract, customer
+  obligations, investor rights, or any financial return.
+
+Sponsorship is not investment, not commercial-track engagement, and
+not an employment or consulting relationship.

--- a/docs/commercial/strategic-customer-nre.md
+++ b/docs/commercial/strategic-customer-nre.md
@@ -1,0 +1,30 @@
+---
+orphan: true
+---
+
+> Draft operational policy. Not legal advice. Subject to legal, tax,
+> accounting, securities, and IP counsel review before use. Not an
+> offer to sell securities. Not an investment solicitation.
+> Sponsorship is not investment and provides no financial return.
+> Contributions do not create equity, royalties, revenue share,
+> profit share, employment, sponsorship payments, or investor returns.
+
+# Strategic-customer NRE (draft)
+
+Non-recurring engineering arrangements with strategic customers are
+defined in **separate written contracts**. This page records the
+intended boundaries only.
+
+Strategic customer NRE provides:
+- Evaluation deliverables.
+- Customer-specific porting work under contract.
+- Integration support.
+- Optional license to specified deliverables.
+
+It does **not** provide:
+- Equity, royalties, revenue share, profit share, employment, or
+  investor returns.
+- Production rights without a written licence.
+- Tape-out rights without a written licence.
+
+Pricing and terms are TBD.

--- a/docs/commercial/support-tiers.md
+++ b/docs/commercial/support-tiers.md
@@ -1,0 +1,24 @@
+---
+orphan: true
+---
+
+> Draft operational policy. Not legal advice. Subject to legal, tax,
+> accounting, securities, and IP counsel review before use. Not an
+> offer to sell securities. Not an investment solicitation.
+> Sponsorship is not investment and provides no financial return.
+> Contributions do not create equity, royalties, revenue share,
+> profit share, employment, sponsorship payments, or investor returns.
+
+# Support tiers (draft)
+
+Support is provided under separate written contracts to commercial
+customers. Open-track users receive best-effort community support
+only.
+
+Anticipated tiers:
+- **Community**: GitHub issues / discussions, no SLA.
+- **Standard**: scoped technical support, response time TBD.
+- **Enterprise**: custom SLA, integration support, certification
+  harness access.
+
+Pricing TBD.

--- a/docs/evidence/benchmark-report-template.md
+++ b/docs/evidence/benchmark-report-template.md
@@ -1,0 +1,27 @@
+---
+orphan: true
+---
+
+> Draft operational policy. Not legal advice. Subject to legal, tax,
+> accounting, securities, and IP counsel review before use. Not an
+> offer to sell securities. Not an investment solicitation.
+> Sponsorship is not investment and provides no financial return.
+> Contributions do not create equity, royalties, revenue share,
+> profit share, employment, sponsorship payments, or investor returns.
+
+# Benchmark report (template)
+
+Public-safe template for benchmark reports. **Do not publish a
+benchmark number without measured evidence and reproducible
+command.**
+
+Required fields:
+- Hardware (board, clock, voltage, memory)
+- Software (driver, runtime, model name+version, weight format)
+- Workload (input shape, batch size, context length)
+- Measured value with units, p50 / p95
+- Reproduction command
+- Variability / repeats
+- Known biases or simulator-only flags
+
+Where any field is missing, the report is incomplete.

--- a/docs/evidence/conformance-suite-plan.md
+++ b/docs/evidence/conformance-suite-plan.md
@@ -1,0 +1,25 @@
+---
+orphan: true
+---
+
+> Draft operational policy. Not legal advice. Subject to legal, tax,
+> accounting, securities, and IP counsel review before use. Not an
+> offer to sell securities. Not an investment solicitation.
+> Sponsorship is not investment and provides no financial return.
+> Contributions do not create equity, royalties, revenue share,
+> profit share, employment, sponsorship payments, or investor returns.
+
+# PCCX Conformance suite plan (draft)
+
+The PCCX™ Conformance suite is the future test-set that backs
+'PCCX Compatible' badges. **No PCCX Compatible badge is granted
+today**; use of the term is reserved.
+
+Suite scope (planned):
+- ISA conformance.
+- Register/memory map conformance.
+- Driver ABI conformance.
+- Sim wrapper sanity.
+
+The suite is gated on a published conformance process and a written
+approval workflow. Tracker: pccxai/pccx#61.

--- a/docs/evidence/customer-evidence-pack-template.md
+++ b/docs/evidence/customer-evidence-pack-template.md
@@ -1,0 +1,26 @@
+---
+orphan: true
+---
+
+> Draft operational policy. Not legal advice. Subject to legal, tax,
+> accounting, securities, and IP counsel review before use. Not an
+> offer to sell securities. Not an investment solicitation.
+> Sponsorship is not investment and provides no financial return.
+> Contributions do not create equity, royalties, revenue share,
+> profit share, employment, sponsorship payments, or investor returns.
+
+# Customer evidence pack (template)
+
+Public-safe template for evidence handed to customers under a
+written engagement. **No customer-specific content lives in public
+repos.**
+
+Sections:
+- Purpose / scope
+- Hardware target (board, model)
+- Measured tokens-per-second / FPS / mAP / latency / power **only if measured**
+- CI / sim / formal evidence URLs
+- Source manifest / SHA pin
+- Limitations and known risks (no production claim)
+
+Where there is no measurement, the field is **TBD**, not a guess.

--- a/docs/evidence/no-unsupported-claims-policy.md
+++ b/docs/evidence/no-unsupported-claims-policy.md
@@ -1,0 +1,36 @@
+---
+orphan: true
+---
+
+> Draft operational policy. Not legal advice. Subject to legal, tax,
+> accounting, securities, and IP counsel review before use. Not an
+> offer to sell securities. Not an investment solicitation.
+> Sponsorship is not investment and provides no financial return.
+> Contributions do not create equity, royalties, revenue share,
+> profit share, employment, sponsorship payments, or investor returns.
+
+# No-unsupported-claims policy
+
+PCCX™ public docs and PRs must not claim any of the following
+without measured, reproducible evidence (each phrase is the
+*exact* claim form that requires evidence):
+
+- on-board KV260 inference operability
+- end-to-end Gemma 3N E4B runtime on KV260
+- numeric tokens-per-second targets (e.g. 20 tok/s)
+- timing-closure completion
+- bitstream-success outcomes
+- production-readiness
+- stable application interface or stable application binary interface
+- conformance certification (e.g. an "official" badge or a
+  "PCCX-Compatible" badge)
+- frames-per-second numeric figures
+- mean-average-precision numeric figures
+
+In short: any phrase that asserts the existence of a measured
+hardware / runtime / timing / bitstream / latency / accuracy /
+certification outcome must be backed by a reproducible measurement
+or marked TBD.
+
+The CI banned-claim grep is run before merge of any release / docs /
+metadata PR. See `docs/evidence/release-evidence-gate.md`.

--- a/docs/evidence/release-evidence-gate.md
+++ b/docs/evidence/release-evidence-gate.md
@@ -1,0 +1,24 @@
+---
+orphan: true
+---
+
+> Draft operational policy. Not legal advice. Subject to legal, tax,
+> accounting, securities, and IP counsel review before use. Not an
+> offer to sell securities. Not an investment solicitation.
+> Sponsorship is not investment and provides no financial return.
+> Contributions do not create equity, royalties, revenue share,
+> profit share, employment, sponsorship payments, or investor returns.
+
+# Release evidence gate (policy)
+
+Releases are evidence-gated. Each public PCCX™ release that mentions
+hardware / runtime / timing / bitstream evidence must include:
+
+- exact reproduction command
+- measured value or 'TBD'
+- CI / sim / formal run URL
+- source manifest / SHA pin
+- known limitations
+
+Without these, a release does not claim the corresponding evidence.
+Phase release dates are aspirational; no production claim.

--- a/docs/investor/customer-pipeline-template.md
+++ b/docs/investor/customer-pipeline-template.md
@@ -1,0 +1,24 @@
+---
+orphan: true
+---
+
+> Draft operational policy. Not legal advice. Subject to legal, tax,
+> accounting, securities, and IP counsel review before use. Not an
+> offer to sell securities. Not an investment solicitation.
+> Sponsorship is not investment and provides no financial return.
+> Contributions do not create equity, royalties, revenue share,
+> profit share, employment, sponsorship payments, or investor returns.
+
+# Customer pipeline (template)
+
+Public-safe planning template. **Customer-specific data lives in
+the private data room.**
+
+Stages:
+- Awareness.
+- Evaluation under NDA.
+- Pilot under NRE.
+- Production licence.
+- Renewal / certification.
+
+No customer is named in public artefacts.

--- a/docs/investor/data-room-index.md
+++ b/docs/investor/data-room-index.md
@@ -1,0 +1,27 @@
+---
+orphan: true
+---
+
+> Draft operational policy. Not legal advice. Subject to legal, tax,
+> accounting, securities, and IP counsel review before use. Not an
+> offer to sell securities. Not an investment solicitation.
+> Sponsorship is not investment and provides no financial return.
+> Contributions do not create equity, royalties, revenue share,
+> profit share, employment, sponsorship payments, or investor returns.
+
+# Data-room index (template)
+
+Public-safe index of the topics a PCCX™ data room would contain.
+**The actual data room is not public.**
+
+Topics:
+- Corporate structure.
+- IP layered overview.
+- Trademark filings (KIPRIS-public values only).
+- Patent posture (categories only).
+- Trade-secret list (count only, not contents).
+- Engineering evidence summary (with reproduction commands).
+- Capital track summary (sponsor / strategic customer / investor).
+- Risk register summary.
+
+Each row is satisfied by a private artefact reviewed by counsel.

--- a/docs/investor/revenue-model-template.md
+++ b/docs/investor/revenue-model-template.md
@@ -1,0 +1,24 @@
+---
+orphan: true
+---
+
+> Draft operational policy. Not legal advice. Subject to legal, tax,
+> accounting, securities, and IP counsel review before use. Not an
+> offer to sell securities. Not an investment solicitation.
+> Sponsorship is not investment and provides no financial return.
+> Contributions do not create equity, royalties, revenue share,
+> profit share, employment, sponsorship payments, or investor returns.
+
+# Revenue model (template)
+
+Public-safe planning template. **Not investment advice and not a
+solicitation.**
+
+Channels:
+- ProCore commercial licence.
+- Enterprise SDK / compiler backend.
+- ASICKit deliverables.
+- Customer NRE / porting / integration support.
+- Certification.
+
+Pricing per channel TBD.

--- a/docs/investor/use-of-funds-template.md
+++ b/docs/investor/use-of-funds-template.md
@@ -1,0 +1,24 @@
+---
+orphan: true
+---
+
+> Draft operational policy. Not legal advice. Subject to legal, tax,
+> accounting, securities, and IP counsel review before use. Not an
+> offer to sell securities. Not an investment solicitation.
+> Sponsorship is not investment and provides no financial return.
+> Contributions do not create equity, royalties, revenue share,
+> profit share, employment, sponsorship payments, or investor returns.
+
+# Use of funds (template)
+
+Public-safe planning template. **Not investment advice and not a
+solicitation.**
+
+Categories:
+- Engineering capacity (TBD).
+- Verification / sim / lab capacity (TBD).
+- Foreign-filing fees within Madrid window (TBD).
+- ASIC tape-out reserve (future).
+- Operational overhead (legal, accounting, admin).
+
+All amounts are TBD pending qualified counsel review.

--- a/docs/ip/copyright-snapshot-plan.md
+++ b/docs/ip/copyright-snapshot-plan.md
@@ -1,0 +1,23 @@
+---
+orphan: true
+---
+
+> Draft operational policy. Not legal advice. Subject to legal, tax,
+> accounting, securities, and IP counsel review before use. Not an
+> offer to sell securities. Not an investment solicitation.
+> Sponsorship is not investment and provides no financial return.
+> Contributions do not create equity, royalties, revenue share,
+> profit share, employment, sponsorship payments, or investor returns.
+
+# Copyright snapshot plan (draft)
+
+Beyond per-file SPDX coverage, the project may register specific
+*snapshots* of an artefact (e.g. a tagged release) under the Korea
+Copyright Commission or another jurisdiction's registry.
+
+Default position: per-file SPDX is sufficient for most cases.
+Optional snapshot registration when:
+- A jurisdiction requires registration to obtain remedies.
+- A commercial customer needs an evidentiary snapshot.
+
+Specific filings are tracked privately.

--- a/docs/ip/founder-ip-assignment-checklist-public.md
+++ b/docs/ip/founder-ip-assignment-checklist-public.md
@@ -1,0 +1,23 @@
+---
+orphan: true
+---
+
+> Draft operational policy. Not legal advice. Subject to legal, tax,
+> accounting, securities, and IP counsel review before use. Not an
+> offer to sell securities. Not an investment solicitation.
+> Sponsorship is not investment and provides no financial return.
+> Contributions do not create equity, royalties, revenue share,
+> profit share, employment, sponsorship payments, or investor returns.
+
+# Founder IP assignment checklist (public summary)
+
+Public-safe summary of the assignment readiness review:
+
+- [ ] Identify each contributor (founder + others).
+- [ ] Confirm whether contribution was made under an employer's IP rights.
+- [ ] Confirm repository licences cover contributions adequately.
+- [ ] Identify contributions needing explicit assignment to any future entity.
+- [ ] Identify any work-for-hire / agency / spousal-consent issues.
+
+The full checklist plus the actual assignment instruments are kept
+private and reviewed by qualified counsel before signature.

--- a/docs/ip/patent-candidate-public-summary.md
+++ b/docs/ip/patent-candidate-public-summary.md
@@ -1,0 +1,28 @@
+---
+orphan: true
+---
+
+> Draft operational policy. Not legal advice. Subject to legal, tax,
+> accounting, securities, and IP counsel review before use. Not an
+> offer to sell securities. Not an investment solicitation.
+> Sponsorship is not investment and provides no financial return.
+> Contributions do not create equity, royalties, revenue share,
+> profit share, employment, sponsorship payments, or investor returns.
+
+# Patent candidate (public summary only)
+
+The project tracks *categories* of patent candidates publicly. Each
+specific candidate is held in a private docket
+(`pccxai/pccx-ip-docket-private`).
+
+Categories listed publicly (no specific inventions):
+- Quantization / arithmetic-pipeline boundary structures
+- Memory-bound Transformer scheduling structures specific to
+  KV-cache traffic
+- Custom ISA encodings tuned for decoupled-dataflow
+- Compiler / runtime techniques mapping model graphs onto the
+  IP-core instruction stream
+- Verification harness techniques producing reproducible evidence
+  packs
+
+The intake procedure is in `docs/ip/patent-candidate-intake.md`.

--- a/docs/ip/public-private-disclosure-matrix.md
+++ b/docs/ip/public-private-disclosure-matrix.md
@@ -1,0 +1,29 @@
+---
+orphan: true
+---
+
+> Draft operational policy. Not legal advice. Subject to legal, tax,
+> accounting, securities, and IP counsel review before use. Not an
+> offer to sell securities. Not an investment solicitation.
+> Sponsorship is not investment and provides no financial return.
+> Contributions do not create equity, royalties, revenue share,
+> profit share, employment, sponsorship payments, or investor returns.
+
+# Public / private disclosure matrix
+
+Where each artefact lives.
+
+| Layer | Public | Private (separate confidentiality controls) |
+| --- | --- | --- |
+| Spec / ISA / public docs | yes | n/a |
+| OpenCore RTL | yes | n/a |
+| ProCore RTL bundles | n/a | yes |
+| Compiler backend (closed) | n/a | yes |
+| ASICKit deliverables | n/a | yes |
+| PPA / timing scripts | n/a | yes |
+| Customer-specific work | n/a | yes (per contract) |
+| Trademark filing customer numbers / receipts / contact details | n/a | yes |
+| Detailed patent claims for not-yet-public candidates | n/a | yes |
+
+Public artefacts are licensed under the existing open licence;
+private artefacts are not.

--- a/docs/ip/trade-secret-handling.md
+++ b/docs/ip/trade-secret-handling.md
@@ -1,0 +1,23 @@
+---
+orphan: true
+---
+
+> Draft operational policy. Not legal advice. Subject to legal, tax,
+> accounting, securities, and IP counsel review before use. Not an
+> offer to sell securities. Not an investment solicitation.
+> Sponsorship is not investment and provides no financial return.
+> Contributions do not create equity, royalties, revenue share,
+> profit share, employment, sponsorship payments, or investor returns.
+
+# Trade-secret handling (operational)
+
+Trade secrets:
+- Live outside public repos.
+- Are accessed under written confidentiality controls (NDAs,
+  employment agreements, commercial contracts).
+- Are not patented (publication forfeits secrecy; choose patent or
+  trade-secret per candidate, not both).
+
+Public artefacts are not trade secret. Once published in
+`pccxai/*` open repositories, content is no longer trade-secret
+protected.

--- a/ko/docs/commercial/asickit-roadmap.md
+++ b/ko/docs/commercial/asickit-roadmap.md
@@ -1,0 +1,10 @@
+---
+orphan: true
+---
+
+# (자동 번역 대기)
+
+이 페이지는 영문판이 정본입니다. 자동 번역 도구가 채울 자리이며,
+신규 본문을 한국어로 직접 작성하지 마세요.
+
+영문 원본: `docs/commercial/asickit-roadmap.md` — <https://github.com/pccxai/pccx/blob/main/docs/commercial/asickit-roadmap.md>

--- a/ko/docs/commercial/investor-overview-draft.md
+++ b/ko/docs/commercial/investor-overview-draft.md
@@ -1,0 +1,10 @@
+---
+orphan: true
+---
+
+# (자동 번역 대기)
+
+이 페이지는 영문판이 정본입니다. 자동 번역 도구가 채울 자리이며,
+신규 본문을 한국어로 직접 작성하지 마세요.
+
+영문 원본: `docs/commercial/investor-overview-draft.md` — <https://github.com/pccxai/pccx/blob/main/docs/commercial/investor-overview-draft.md>

--- a/ko/docs/commercial/procore-evaluation-kit.md
+++ b/ko/docs/commercial/procore-evaluation-kit.md
@@ -1,0 +1,10 @@
+---
+orphan: true
+---
+
+# (자동 번역 대기)
+
+이 페이지는 영문판이 정본입니다. 자동 번역 도구가 채울 자리이며,
+신규 본문을 한국어로 직접 작성하지 마세요.
+
+영문 원본: `docs/commercial/procore-evaluation-kit.md` — <https://github.com/pccxai/pccx/blob/main/docs/commercial/procore-evaluation-kit.md>

--- a/ko/docs/commercial/product-packages.md
+++ b/ko/docs/commercial/product-packages.md
@@ -1,0 +1,10 @@
+---
+orphan: true
+---
+
+# (자동 번역 대기)
+
+이 페이지는 영문판이 정본입니다. 자동 번역 도구가 채울 자리이며,
+신규 본문을 한국어로 직접 작성하지 마세요.
+
+영문 원본: `docs/commercial/product-packages.md` — <https://github.com/pccxai/pccx/blob/main/docs/commercial/product-packages.md>

--- a/ko/docs/commercial/public-private-roadmap.md
+++ b/ko/docs/commercial/public-private-roadmap.md
@@ -1,0 +1,10 @@
+---
+orphan: true
+---
+
+# (자동 번역 대기)
+
+이 페이지는 영문판이 정본입니다. 자동 번역 도구가 채울 자리이며,
+신규 본문을 한국어로 직접 작성하지 마세요.
+
+영문 원본: `docs/commercial/public-private-roadmap.md` — <https://github.com/pccxai/pccx/blob/main/docs/commercial/public-private-roadmap.md>

--- a/ko/docs/commercial/risk-factors.md
+++ b/ko/docs/commercial/risk-factors.md
@@ -1,0 +1,10 @@
+---
+orphan: true
+---
+
+# (자동 번역 대기)
+
+이 페이지는 영문판이 정본입니다. 자동 번역 도구가 채울 자리이며,
+신규 본문을 한국어로 직접 작성하지 마세요.
+
+영문 원본: `docs/commercial/risk-factors.md` — <https://github.com/pccxai/pccx/blob/main/docs/commercial/risk-factors.md>

--- a/ko/docs/commercial/sponsorship-policy.md
+++ b/ko/docs/commercial/sponsorship-policy.md
@@ -1,0 +1,10 @@
+---
+orphan: true
+---
+
+# (자동 번역 대기)
+
+이 페이지는 영문판이 정본입니다. 자동 번역 도구가 채울 자리이며,
+신규 본문을 한국어로 직접 작성하지 마세요.
+
+영문 원본: `docs/commercial/sponsorship-policy.md` — <https://github.com/pccxai/pccx/blob/main/docs/commercial/sponsorship-policy.md>

--- a/ko/docs/commercial/strategic-customer-nre.md
+++ b/ko/docs/commercial/strategic-customer-nre.md
@@ -1,0 +1,10 @@
+---
+orphan: true
+---
+
+# (자동 번역 대기)
+
+이 페이지는 영문판이 정본입니다. 자동 번역 도구가 채울 자리이며,
+신규 본문을 한국어로 직접 작성하지 마세요.
+
+영문 원본: `docs/commercial/strategic-customer-nre.md` — <https://github.com/pccxai/pccx/blob/main/docs/commercial/strategic-customer-nre.md>

--- a/ko/docs/commercial/support-tiers.md
+++ b/ko/docs/commercial/support-tiers.md
@@ -1,0 +1,10 @@
+---
+orphan: true
+---
+
+# (자동 번역 대기)
+
+이 페이지는 영문판이 정본입니다. 자동 번역 도구가 채울 자리이며,
+신규 본문을 한국어로 직접 작성하지 마세요.
+
+영문 원본: `docs/commercial/support-tiers.md` — <https://github.com/pccxai/pccx/blob/main/docs/commercial/support-tiers.md>

--- a/ko/docs/evidence/benchmark-report-template.md
+++ b/ko/docs/evidence/benchmark-report-template.md
@@ -1,0 +1,10 @@
+---
+orphan: true
+---
+
+# (자동 번역 대기)
+
+이 페이지는 영문판이 정본입니다. 자동 번역 도구가 채울 자리이며,
+신규 본문을 한국어로 직접 작성하지 마세요.
+
+영문 원본: `docs/evidence/benchmark-report-template.md` — <https://github.com/pccxai/pccx/blob/main/docs/evidence/benchmark-report-template.md>

--- a/ko/docs/evidence/conformance-suite-plan.md
+++ b/ko/docs/evidence/conformance-suite-plan.md
@@ -1,0 +1,10 @@
+---
+orphan: true
+---
+
+# (자동 번역 대기)
+
+이 페이지는 영문판이 정본입니다. 자동 번역 도구가 채울 자리이며,
+신규 본문을 한국어로 직접 작성하지 마세요.
+
+영문 원본: `docs/evidence/conformance-suite-plan.md` — <https://github.com/pccxai/pccx/blob/main/docs/evidence/conformance-suite-plan.md>

--- a/ko/docs/evidence/customer-evidence-pack-template.md
+++ b/ko/docs/evidence/customer-evidence-pack-template.md
@@ -1,0 +1,10 @@
+---
+orphan: true
+---
+
+# (자동 번역 대기)
+
+이 페이지는 영문판이 정본입니다. 자동 번역 도구가 채울 자리이며,
+신규 본문을 한국어로 직접 작성하지 마세요.
+
+영문 원본: `docs/evidence/customer-evidence-pack-template.md` — <https://github.com/pccxai/pccx/blob/main/docs/evidence/customer-evidence-pack-template.md>

--- a/ko/docs/evidence/no-unsupported-claims-policy.md
+++ b/ko/docs/evidence/no-unsupported-claims-policy.md
@@ -1,0 +1,10 @@
+---
+orphan: true
+---
+
+# (자동 번역 대기)
+
+이 페이지는 영문판이 정본입니다. 자동 번역 도구가 채울 자리이며,
+신규 본문을 한국어로 직접 작성하지 마세요.
+
+영문 원본: `docs/evidence/no-unsupported-claims-policy.md` — <https://github.com/pccxai/pccx/blob/main/docs/evidence/no-unsupported-claims-policy.md>

--- a/ko/docs/evidence/release-evidence-gate.md
+++ b/ko/docs/evidence/release-evidence-gate.md
@@ -1,0 +1,10 @@
+---
+orphan: true
+---
+
+# (자동 번역 대기)
+
+이 페이지는 영문판이 정본입니다. 자동 번역 도구가 채울 자리이며,
+신규 본문을 한국어로 직접 작성하지 마세요.
+
+영문 원본: `docs/evidence/release-evidence-gate.md` — <https://github.com/pccxai/pccx/blob/main/docs/evidence/release-evidence-gate.md>

--- a/ko/docs/investor/customer-pipeline-template.md
+++ b/ko/docs/investor/customer-pipeline-template.md
@@ -1,0 +1,10 @@
+---
+orphan: true
+---
+
+# (자동 번역 대기)
+
+이 페이지는 영문판이 정본입니다. 자동 번역 도구가 채울 자리이며,
+신규 본문을 한국어로 직접 작성하지 마세요.
+
+영문 원본: `docs/investor/customer-pipeline-template.md` — <https://github.com/pccxai/pccx/blob/main/docs/investor/customer-pipeline-template.md>

--- a/ko/docs/investor/data-room-index.md
+++ b/ko/docs/investor/data-room-index.md
@@ -1,0 +1,10 @@
+---
+orphan: true
+---
+
+# (자동 번역 대기)
+
+이 페이지는 영문판이 정본입니다. 자동 번역 도구가 채울 자리이며,
+신규 본문을 한국어로 직접 작성하지 마세요.
+
+영문 원본: `docs/investor/data-room-index.md` — <https://github.com/pccxai/pccx/blob/main/docs/investor/data-room-index.md>

--- a/ko/docs/investor/revenue-model-template.md
+++ b/ko/docs/investor/revenue-model-template.md
@@ -1,0 +1,10 @@
+---
+orphan: true
+---
+
+# (자동 번역 대기)
+
+이 페이지는 영문판이 정본입니다. 자동 번역 도구가 채울 자리이며,
+신규 본문을 한국어로 직접 작성하지 마세요.
+
+영문 원본: `docs/investor/revenue-model-template.md` — <https://github.com/pccxai/pccx/blob/main/docs/investor/revenue-model-template.md>

--- a/ko/docs/investor/use-of-funds-template.md
+++ b/ko/docs/investor/use-of-funds-template.md
@@ -1,0 +1,10 @@
+---
+orphan: true
+---
+
+# (자동 번역 대기)
+
+이 페이지는 영문판이 정본입니다. 자동 번역 도구가 채울 자리이며,
+신규 본문을 한국어로 직접 작성하지 마세요.
+
+영문 원본: `docs/investor/use-of-funds-template.md` — <https://github.com/pccxai/pccx/blob/main/docs/investor/use-of-funds-template.md>

--- a/ko/docs/ip/copyright-snapshot-plan.md
+++ b/ko/docs/ip/copyright-snapshot-plan.md
@@ -1,0 +1,10 @@
+---
+orphan: true
+---
+
+# (자동 번역 대기)
+
+이 페이지는 영문판이 정본입니다. 자동 번역 도구가 채울 자리이며,
+신규 본문을 한국어로 직접 작성하지 마세요.
+
+영문 원본: `docs/ip/copyright-snapshot-plan.md` — <https://github.com/pccxai/pccx/blob/main/docs/ip/copyright-snapshot-plan.md>

--- a/ko/docs/ip/founder-ip-assignment-checklist-public.md
+++ b/ko/docs/ip/founder-ip-assignment-checklist-public.md
@@ -1,0 +1,10 @@
+---
+orphan: true
+---
+
+# (자동 번역 대기)
+
+이 페이지는 영문판이 정본입니다. 자동 번역 도구가 채울 자리이며,
+신규 본문을 한국어로 직접 작성하지 마세요.
+
+영문 원본: `docs/ip/founder-ip-assignment-checklist-public.md` — <https://github.com/pccxai/pccx/blob/main/docs/ip/founder-ip-assignment-checklist-public.md>

--- a/ko/docs/ip/patent-candidate-public-summary.md
+++ b/ko/docs/ip/patent-candidate-public-summary.md
@@ -1,0 +1,10 @@
+---
+orphan: true
+---
+
+# (자동 번역 대기)
+
+이 페이지는 영문판이 정본입니다. 자동 번역 도구가 채울 자리이며,
+신규 본문을 한국어로 직접 작성하지 마세요.
+
+영문 원본: `docs/ip/patent-candidate-public-summary.md` — <https://github.com/pccxai/pccx/blob/main/docs/ip/patent-candidate-public-summary.md>

--- a/ko/docs/ip/public-private-disclosure-matrix.md
+++ b/ko/docs/ip/public-private-disclosure-matrix.md
@@ -1,0 +1,10 @@
+---
+orphan: true
+---
+
+# (자동 번역 대기)
+
+이 페이지는 영문판이 정본입니다. 자동 번역 도구가 채울 자리이며,
+신규 본문을 한국어로 직접 작성하지 마세요.
+
+영문 원본: `docs/ip/public-private-disclosure-matrix.md` — <https://github.com/pccxai/pccx/blob/main/docs/ip/public-private-disclosure-matrix.md>

--- a/ko/docs/ip/trade-secret-handling.md
+++ b/ko/docs/ip/trade-secret-handling.md
@@ -1,0 +1,10 @@
+---
+orphan: true
+---
+
+# (자동 번역 대기)
+
+이 페이지는 영문판이 정본입니다. 자동 번역 도구가 채울 자리이며,
+신규 본문을 한국어로 직접 작성하지 마세요.
+
+영문 원본: `docs/ip/trade-secret-handling.md` — <https://github.com/pccxai/pccx/blob/main/docs/ip/trade-secret-handling.md>


### PR DESCRIPTION
Adds public-safe draft commercial, evidence, IP, and investor data-room templates. Non-binding, not legal advice, not investment solicitation, no private filing material, no unsupported hardware/runtime/timing/bitstream/FPS/mAP claims. 23 EN docs + 23 KO mirror stubs across docs/{commercial,evidence,ip,investor}/.