### PR TITLE
Replace stale v003/vision-v001 URL TBD phrasing with current public repo URLs

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -50,7 +50,7 @@ Tracking issue: [pccxai/pccx#28 — v0.2.0 umbrella][v020].
 ## Later — v003.x: separate RTL repository (LLM line continued)
 
 - v003+ active RTL development moves to a dedicated repository, working
-  name `pccx-LLM-v003`, public URL TBD; the v003 RTL repository has
+  name [`pccx-LLM-v003`](https://github.com/pccxai/pccx-LLM-v003) (temporary planning line; canonical home is [`pccx-v003`](https://github.com/pccxai/pccx-v003)); the v003 RTL repository has
   not yet stabilised any release branch
 - this docs repo will cross-link the v003 RTL repository and CI-clone
   it into `codes/v003/` at build time, the same way it currently
@@ -67,7 +67,7 @@ KV260 board and the W4A8 NPU substrate but covers a distinct workload
 family from the LLM line. Active RTL development will live in a
 dedicated repository.
 
-- working name `pccx-vision-v001`, public URL TBD
+- [`pccx-vision-v001`](https://github.com/pccxai/pccx-vision-v001)
 - shared substrate with the LLM line — same KV260 board, same W4A8
   weight × activation ratio, same L2 URAM organisation
 - distinct dataflow — dense-conv tile reuse instead of token-by-token

--- a/docs/vision-v001/index.md
+++ b/docs/vision-v001/index.md
@@ -9,7 +9,7 @@ upstream RTL repository stabilises.
 
 ## Working state
 
-- working repository name: `pccx-vision-v001`, public URL TBD
+- repository: [`pccxai/pccx-vision-v001`](https://github.com/pccxai/pccx-vision-v001)
 - working staging repository: `pccx-vision-v001-staging` (private)
 - shared substrate with v002 — same KV260 board, same W4A8 weight ×
   activation ratio, same L2 URAM organisation

--- a/ko/docs/roadmap.md
+++ b/ko/docs/roadmap.md
@@ -50,7 +50,7 @@ KV260 bring-up `[HW]` → 런타임 `[HW]` → 릴리스 증거 체크리스트
 ## Later — v003.x: 별도 RTL 저장소 (LLM 라인 후속)
 
 - v003+ 의 활성 RTL 개발은 별도 저장소로 분리, 작업 이름
-  `pccx-LLM-v003`, 공개 URL 미정; v003 RTL 저장소는 아직 안정된
+  [`pccx-LLM-v003`](https://github.com/pccxai/pccx-LLM-v003) (임시 계획 라인; 정본 위치는 [`pccx-v003`](https://github.com/pccxai/pccx-v003)); v003 RTL 저장소는 아직 안정된
   릴리스 브랜치를 가지지 않았다
 - 이 문서 저장소는 v003 RTL 저장소를 cross-link 하고 빌드 시
   `codes/v003/` 로 CI-clone 한다 — 현재
@@ -66,7 +66,7 @@ LLM 라인과는 별개로, **vision** 워크로드 전용 두 번째 제품 라
 운영한다. 동일한 KV260 보드와 W4A8 NPU 기반을 공유하면서도 워크
 로드 family 는 다르다. 활성 RTL 개발은 전용 저장소에서 진행된다.
 
-- 작업 이름 `pccx-vision-v001`, 공개 URL 미정
+- [`pccx-vision-v001`](https://github.com/pccxai/pccx-vision-v001)
 - LLM 라인과 substrate 공유 — 같은 KV260 보드, 같은 W4A8
   weight × activation 비율, 같은 L2 URAM 구성
 - 데이터플로우는 다름 — 토큰 단위 KV 스트리밍이 아니라 dense conv

--- a/ko/docs/v003/index.md
+++ b/ko/docs/v003/index.md
@@ -7,7 +7,7 @@ v003 라인은 {doc}`v002 라인 <../v002/index>` 의 **LLM 트랙**을
 
 ## 작업 상태
 
-- 작업 저장소 이름: `pccx-LLM-v003`, 공개 URL 미정
+- 임시 계획 라인 저장소: [`pccx-LLM-v003`](https://github.com/pccxai/pccx-LLM-v003) (정본은 [`pccx-v003`](https://github.com/pccxai/pccx-v003))
 - 작업 staging 저장소: `pccx-LLM-v003-staging` (private)
 - 저장소는 evidence-tracked 상태로 생성됨; 안정된 릴리스 브랜치는
   아직 없음

--- a/ko/docs/vision-v001/index.md
+++ b/ko/docs/vision-v001/index.md
@@ -9,7 +9,7 @@ placeholder 다.
 
 ## 작업 상태
 
-- 작업 저장소 이름: `pccx-vision-v001`, 공개 URL 미정
+- 저장소: [`pccxai/pccx-vision-v001`](https://github.com/pccxai/pccx-vision-v001)
 - 작업 staging 저장소: `pccx-vision-v001-staging` (private)
 - v002 와 substrate 공유 — 동일한 KV260 보드, 동일한 W4A8
   weight × activation 비율, 동일한 L2 URAM 구성

--- a/ko/index.rst
+++ b/ko/index.rst
@@ -64,7 +64,7 @@ pccx는 엣지 디바이스에서 Transformer 기반 LLM을 가속하기 위한
             **hkimw.github.io/hkimw** — 블로그, 다른 프로젝트, 소개.
 
 v003+ 의 활성 RTL 개발은 별도 저장소로 분리됩니다 — 작업 이름
-``pccxai/pccx-FPGA-NPU-LLM-v003``, 공개 URL 미정. 호스팅 방식은 v002
+`pccxai/pccx-v003 <https://github.com/pccxai/pccx-v003>`_. 호스팅 방식은 v002
 와 동일합니다: 이 문서 저장소는 v003 RTL 저장소를 cross-link 하고,
 빌드 시 ``codes/v003/`` 로 CI-clone 합니다 — 현재
 ``pccx-FPGA-NPU-LLM-kv260`` 를 ``codes/v002/`` 로 CI-clone 하는


### PR DESCRIPTION
Updates 6 docs (EN + KO) that still said `public URL TBD` / `공개 URL 미정` / referenced a non-existent `pccxai/pccx-FPGA-NPU-LLM-v003` typo to point at the current public repos:

- pccxai/pccx-LLM-v003 (temporary planning line)
- pccxai/pccx-v003 (canonical v003 IP-core planning package, created Phase AB)
- pccxai/pccx-vision-v001 (vision compatibility track)

No code behavior changes. No hardware/runtime/timing/bitstream/FPS/mAP claim added. Trademark wording unchanged.