### PR TITLE
Remove final stale v003 homepage wording

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -54,9 +54,11 @@ Ecosystem
 
             **hkimw.github.io/hkimw** — blog, other projects, about.
 
-v003 IP-core development belongs to the future ``pccx-v003`` package.
-Board and model repositories will consume that package through explicit
-compatibility contracts.
+The public ``pccx-v003`` repository now serves as the v003 IP-core
+planning package. It is an evidence-gated planning package, not a
+stable RTL release. The temporary ``pccx-LLM-v003`` line feeds the
+v003 LLM planning track, while board and model repositories consume
+v003 material only through explicit compatibility contracts.
 
 Tooling & Lab
 -------------

--- a/ko/index.rst
+++ b/ko/index.rst
@@ -63,12 +63,12 @@ pccx는 엣지 디바이스에서 Transformer 기반 LLM을 가속하기 위한
 
             **hkimw.github.io/hkimw** — 블로그, 다른 프로젝트, 소개.
 
-v003+ 의 활성 RTL 개발은 별도 저장소로 분리됩니다 — 작업 이름
-`pccxai/pccx-v003 <https://github.com/pccxai/pccx-v003>`_. 호스팅 방식은 v002
-와 동일합니다: 이 문서 저장소는 v003 RTL 저장소를 cross-link 하고,
-빌드 시 ``codes/v003/`` 로 CI-clone 합니다 — 현재
-``pccx-FPGA-NPU-LLM-kv260`` 를 ``codes/v002/`` 로 CI-clone 하는
-것과 같은 방식입니다. v003 RTL 저장소는 아직 생성되지 않았습니다.
+공개 `pccxai/pccx-v003 <https://github.com/pccxai/pccx-v003>`_ 저장소는
+현재 v003 IP-core planning package 역할을 합니다. 이는 evidence-gated
+planning package이며, stable RTL release가 아닙니다. 임시
+`pccxai/pccx-LLM-v003 <https://github.com/pccxai/pccx-LLM-v003>`_ 라인은
+v003 LLM planning track을 공급하고, 보드/모델 저장소는 명시적인
+compatibility contract를 통해서만 v003 산출물을 소비합니다.
 
 도구 & 랩
 ---------


### PR DESCRIPTION
Removes the last stale v003 homepage/index wording and describes pccx-v003 as the public evidence-gated planning package rather than a missing/future RTL repository.

## Changes

- `index.rst`: replaces `v003 IP-core development belongs to the future ``pccx-v003`` package` with wording describing `pccx-v003` as the public evidence-gated planning package, and notes the temporary `pccx-LLM-v003` LLM planning feeder.
- `ko/index.rst`: replaces the stale block (`pccx-FPGA-NPU-LLM-v003`, `공개 URL 미정`, `v003 RTL 저장소는 아직 생성되지 않았습니다`) with the same evidence-gated wording in Korean, mirroring the EN version.

## Constraints respected

- No code/build/runtime behavior changes.
- No `PCCX®` claim.
- No registered-trademark / `등록상표` claim.
- No timing-closed / bitstream / KV260 runtime / FPS / mAP / tok/s / production-ready claim.
- Both EN and KO point to `https://github.com/pccxai/pccx-v003` and `https://github.com/pccxai/pccx-LLM-v003`.