### PR TITLE
docs(v003): reflect pccx-v003 canonical, retire pccx-LLM-v003 feeder

### DIFF
--- a/_static/diagrams/pccx_family_tree.svg
+++ b/_static/diagrams/pccx_family_tree.svg
@@ -82,9 +82,9 @@ SPDX-License-Identifier: Apache-2.0
   <g class="node">
     <rect class="block-working" x="800" y="100" width="160" height="60"/>
     <text class="t-title" x="880" y="125">v003</text>
-    <text class="t-spec"  x="880" y="142">pccx-LLM-v003</text>
-    <text class="t-spec"  x="880" y="154">Gemma 4 E4B foundation</text>
-    <title>v003 — LLM line continued on a separate RTL repository. Working name pccx-LLM-v003. Gemma 4 E4B foundation; one architectural novelty per release point.</title>
+    <text class="t-spec"  x="880" y="142">pccx-v003</text>
+    <text class="t-spec"  x="880" y="154">Gemma 4 E4B (planning)</text>
+    <title>v003 — LLM line continued on a separate RTL repository. Canonical package: pccx-v003 (planning, evidence-gated). One architectural novelty per release point.</title>
   </g>
 
   <g class="node">

--- a/docs/reference/repo-topology.md
+++ b/docs/reference/repo-topology.md
@@ -16,15 +16,15 @@ references a specific model or board name in `rtl/` or
 | --- | --- |
 | `pccxai/pccx` | Canonical specification, public documentation site, project index. |
 | `pccxai/pccx-v002` | v002 IP-core package — board- and model-agnostic reusable RTL for LLM and shared subsystems. Vision and Voice domains exist as placeholder directories until those tracks absorb their respective repos. |
-| `pccxai/pccx-LLM-v003` | Placeholder line for the v003 LLM IP-core. Will fold into a future `pccx-v003/LLM/` once the v003 contract is stable. |
+| `pccxai/pccx-v003` | v003 IP-core planning package — same shape as `pccx-v002` (LLM, Vision, Voice, common). Planning / evidence-gated; no v003 RTL or contract is released yet. |
 | `pccxai/pccx-vision-v001` | Standalone vision line on the v002 KV260 substrate. Will fold into `pccx-v002/Vision/` after compatibility review. |
 | `pccxai/pccx-FPGA-NPU-LLM-kv260` | KV260 + LLM application integration. Consumes `pccx-v002` through `third_party/pccx-v002` submodule pinned at `pccx-v002/main`. |
 
-## Future repositories
+## Historical / retired repositories
 
 | Repository | Role |
 | --- | --- |
-| `pccxai/pccx-v003` | Future v003 IP-core package — same shape as `pccx-v002` (LLM, Vision, Voice, common). Created when the v003 contract is stable enough to support a separate package boundary. |
+| `pccxai/pccx-LLM-v003` | Historical temporary feeder for early v003 LLM planning. Superseded by `pccxai/pccx-v003`. No longer an active public track; new reusable v003 LLM material belongs under `pccx-v003/LLM/`. |
 
 ## Placement rule
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -49,13 +49,16 @@ Tracking issue: [pccxai/pccx#28 — v0.2.0 umbrella][v020].
 
 ## Later — v003.x: separate RTL repository (LLM line continued)
 
-- v003+ active RTL development moves to a dedicated repository, working
-  name [`pccx-LLM-v003`](https://github.com/pccxai/pccx-LLM-v003) (temporary planning line; canonical home is [`pccx-v003`](https://github.com/pccxai/pccx-v003)); the v003 RTL repository has
-  not yet stabilised any release branch
-- this docs repo will cross-link the v003 RTL repository and CI-clone
+- v003+ active RTL development lives in
+  [`pccx-v003`](https://github.com/pccxai/pccx-v003), the canonical
+  v003 IP-core planning package; no v003 release branch has stabilised
+  yet (the earlier feeder
+  [`pccx-LLM-v003`](https://github.com/pccxai/pccx-LLM-v003) is
+  superseded / retired)
+- this docs repo will cross-link the v003 IP-core package and CI-clone
   it into `codes/v003/` at build time, the same way it currently
   CI-clones `pccx-FPGA-NPU-LLM-kv260` into `codes/v002/`
-- v003.0 — Gemma 4 E4B foundation + first architectural novelty;
+- v003.0 — Gemma 4 E4B foundation + first architectural novelty (planning);
   throughput TBD
 - v003.1 — second novelty + KV / decoding co-design; throughput TBD
 - placeholder track index: {doc}`v003/index`

--- a/docs/roadmap/milestones.md
+++ b/docs/roadmap/milestones.md
@@ -32,9 +32,10 @@ to advance them.
 - **W4A8 golden-vector gate population** — only smoke vectors
   currently; full fixture set TBD per
   `pccx-FPGA-NPU-LLM-kv260/docs/W4A8_GOLDEN_VECTOR_GATE.md`.
-- **v003 LLM line definition** — `pccxai/pccx-LLM-v003`
-  placeholder repo exists; the eventual `pccx-v003/LLM/` location
-  is the planned home once the v003 contract is stable.
+- **v003 IP-core planning** — `pccxai/pccx-v003` is the canonical v003
+  IP-core planning package (planning / evidence-gated); the earlier
+  feeder `pccxai/pccx-LLM-v003` is superseded / retired and reusable
+  v003 LLM material now belongs under `pccx-v003/LLM/`.
 
 ## Next (gated, no dates)
 
@@ -43,9 +44,9 @@ to advance them.
   default: absorb once the vision RTL is shown to share enough with
   the v002 LLM substrate. If the substrate split is too wide,
   vision stays standalone.
-- **`pccx-v003` repo creation** — gated on v003 contract being
+- **`pccx-v003` contract freeze** — gated on the v003 contract being
   stable enough that an external consumer can pin against it. Until
-  then `pccx-LLM-v003` remains a placeholder track.
+  then `pccx-v003` stays in planning / evidence-gated state.
 - **Voice domain population** — `pccx-v002/Voice/` is a placeholder
   directory today. Population is gated on a defined Voice contract.
 

--- a/docs/v003/compatibility-contract.md
+++ b/docs/v003/compatibility-contract.md
@@ -13,9 +13,10 @@ is intended to live at:
 pccxai/pccx-v003/compatibility/v003-contract.yaml
 ```
 
-(The package repository `pccxai/pccx-v003` does not exist today. See the
-[repository boundary](repository-boundary.md) page for the consolidation
-direction.)
+The canonical package repository [`pccxai/pccx-v003`](https://github.com/pccxai/pccx-v003)
+exists in planning / evidence-gated state; no frozen v003 contract is
+released yet. See the [repository boundary](repository-boundary.md) page
+for the consolidation direction.
 
 ## Contract shape (mirrors v002)
 

--- a/docs/v003/open-questions.md
+++ b/docs/v003/open-questions.md
@@ -37,11 +37,11 @@ orphan: true
 
 ## Repository structure
 
-- When does `pccxai/pccx-v003` get created? Triggered by contract
-  freeze, or by first reusable RTL landing?
-- When does `pccxai/pccx-LLM-v003` get folded into `pccx-v003/LLM/`?
-- Does `pccx-LLM-v003` keep its own README + LICENSE while temporary,
-  or pin a "TBD; absorb pending" placeholder?
+- When does the `pccxai/pccx-v003` contract freeze? Triggered by
+  contract stability, or by first reusable RTL landing?
+- What is the right intake protocol for re-introducing reusable
+  material under `pccx-v003/LLM/` (the historical `pccx-LLM-v003`
+  feeder is now superseded / retired)?
 
 ## Tracker
 

--- a/docs/v003/overview.md
+++ b/docs/v003/overview.md
@@ -23,11 +23,16 @@ verified RTL and a stable contract exist.
 
 ## Current state (planning only)
 
-- A standalone planning repo exists at
-  [`pccxai/pccx-LLM-v003`](https://github.com/pccxai/pccx-LLM-v003) — it is
-  a temporary line for v003 LLM planning and Gemma 4 E4B foundation.
-- A consolidated `pccx-v003` repository **does not exist yet**. The
-  consolidation decision is tracked under
+- The canonical v003 IP-core planning package is
+  [`pccxai/pccx-v003`](https://github.com/pccxai/pccx-v003). It mirrors
+  the published `pccx-v002` layout (`LLM/`, `Vision/`, `Voice/`,
+  `common/`, `compatibility/`, `docs/`, `tests/`, `scripts/`) and is the
+  single predictable location for v003 architecture planning material.
+- The earlier temporary feeder
+  [`pccxai/pccx-LLM-v003`](https://github.com/pccxai/pccx-LLM-v003)
+  is superseded / retired and is no longer an active public track.
+  Any reusable v003 LLM material belongs under `pccx-v003/LLM/`.
+- The consolidation decision is tracked under
   [pccxai/pccx#64](https://github.com/pccxai/pccx/issues/64).
 - No v003 RTL, sim wrapper, formal harness, board integration, or
   contract has been published.
@@ -35,6 +40,7 @@ verified RTL and a stable contract exist.
 ## Source-of-truth links
 
 - v002 IP-core package (released): [`pccxai/pccx-v002`](https://github.com/pccxai/pccx-v002)
-- v003 LLM planning line: [`pccxai/pccx-LLM-v003`](https://github.com/pccxai/pccx-LLM-v003)
+- v003 IP-core planning package (canonical): [`pccxai/pccx-v003`](https://github.com/pccxai/pccx-v003)
+- v003 LLM feeder (historical / retired): [`pccxai/pccx-LLM-v003`](https://github.com/pccxai/pccx-LLM-v003)
 - Tracker: [`pccxai/pccx#64`](https://github.com/pccxai/pccx/issues/64)
 - Canonical docs: <https://pccx.pages.dev/en/>

--- a/docs/v003/repository-boundary.md
+++ b/docs/v003/repository-boundary.md
@@ -8,14 +8,17 @@ orphan: true
 
 ## Today
 
-- **`pccxai/pccx-LLM-v003`** — temporary v003 LLM planning line. Holds
-  early architecture notes and Gemma 4 E4B foundation material. The
-  repository **is not** a stable v003 IP-core package.
-- **`pccxai/pccx-v003`** — does **not** exist yet.
+- **`pccxai/pccx-v003`** — canonical v003 IP-core planning package.
+  Mirrors the `pccx-v002` shape (`LLM/`, `Vision/`, `Voice/`, `common/`,
+  `compatibility/`, `docs/`, `tests/`, `scripts/`). Planning /
+  evidence-gated; no v003 RTL or contract is released yet.
+- **`pccxai/pccx-LLM-v003`** — historical temporary feeder for early
+  v003 LLM planning. Superseded / retired; no longer an active public
+  track. Reusable material belongs under `pccx-v003/LLM/`.
 
 ## Default direction (subject to issue [#64](https://github.com/pccxai/pccx/issues/64))
 
-| Layer | Future location |
+| Layer | Active location |
 | --- | --- |
 | LLM RTL / sim / tb / formal | `pccxai/pccx-v003/LLM/...` (mirroring the `pccx-v002` layout) |
 | Vision RTL | `pccxai/pccx-v003/Vision/...` once a v003 vision substrate is decided |
@@ -26,8 +29,7 @@ orphan: true
 
 ## Boundary rule (unchanged from v002)
 
-The v003 IP-core package, when it exists, follows the same boundary rule
-as v002:
+The v003 IP-core package follows the same boundary rule as v002:
 
 - The model and the board consume the IP core. The IP core never references
   a specific model name or board name inside its `rtl/`, `compatibility/`,
@@ -40,14 +42,15 @@ as v002:
 
 ## Migration sequence (planned)
 
-1. Inventory `pccx-LLM-v003` content and classify each file as
-   IP-core / spec / model-specific.
+1. Inventory historical `pccx-LLM-v003` material (now retired) and
+   classify each file as IP-core / spec / model-specific before any
+   reintroduction under `pccx-v003/LLM/`.
 2. Define `compatibility/v003-contract.yaml` placeholders mirroring the
-   v002 contract shape.
-3. Decide whether to create `pccxai/pccx-v003` immediately or hold the
-   temporary `pccx-LLM-v003` until the contract is stable.
-4. When the package is created, move reusable RTL into the new layout
-   and pin board/model repos to the new package SHA.
+   v002 contract shape inside `pccxai/pccx-v003`.
+3. Reintroduce reusable RTL into the `pccx-v003` layout through fresh,
+   focused PRs after the v003 contract placeholders are updated.
+4. When the package's contract stabilises, pin board/model repos to a
+   v003 package SHA reachable from `pccx-v003/main`.
 
 No timing, runtime, FPS/mAP, bitstream, or production-readiness claim is
 made by this page.

--- a/index.rst
+++ b/index.rst
@@ -56,9 +56,11 @@ Ecosystem
 
 The public ``pccx-v003`` repository now serves as the v003 IP-core
 planning package. It is an evidence-gated planning package, not a
-stable RTL release. The temporary ``pccx-LLM-v003`` line feeds the
-v003 LLM planning track, while board and model repositories consume
-v003 material only through explicit compatibility contracts.
+stable RTL release. The earlier ``pccx-LLM-v003`` feeder is superseded
+/ retired and is no longer an active public track; new reusable v003
+LLM material belongs under ``pccx-v003/LLM/``. Board and model
+repositories consume v003 material only through explicit compatibility
+contracts.
 
 Tooling & Lab
 -------------

--- a/ko/docs/roadmap.md
+++ b/ko/docs/roadmap.md
@@ -49,14 +49,17 @@ KV260 bring-up `[HW]` → 런타임 `[HW]` → 릴리스 증거 체크리스트
 
 ## Later — v003.x: 별도 RTL 저장소 (LLM 라인 후속)
 
-- v003+ 의 활성 RTL 개발은 별도 저장소로 분리, 작업 이름
-  [`pccx-LLM-v003`](https://github.com/pccxai/pccx-LLM-v003) (임시 계획 라인; 정본 위치는 [`pccx-v003`](https://github.com/pccxai/pccx-v003)); v003 RTL 저장소는 아직 안정된
-  릴리스 브랜치를 가지지 않았다
-- 이 문서 저장소는 v003 RTL 저장소를 cross-link 하고 빌드 시
+- v003+ 의 활성 RTL 개발은
+  [`pccx-v003`](https://github.com/pccxai/pccx-v003) — 정본 v003
+  IP-core 계획 패키지 — 에서 진행되며, 안정된 릴리스 브랜치는 아직
+  없다 (이전 feeder
+  [`pccx-LLM-v003`](https://github.com/pccxai/pccx-LLM-v003) 은
+  superseded / retired)
+- 이 문서 저장소는 v003 IP-core 패키지를 cross-link 하고 빌드 시
   `codes/v003/` 로 CI-clone 한다 — 현재
   `pccx-FPGA-NPU-LLM-kv260` 를 `codes/v002/` 로 CI-clone 하는 것과
   같은 방식
-- v003.0 — Gemma 4 E4B 파운데이션 + 첫 아키텍처 novelty; 처리량 TBD
+- v003.0 — Gemma 4 E4B 파운데이션 + 첫 아키텍처 novelty (planning); 처리량 TBD
 - v003.1 — 두 번째 novelty + KV / 디코딩 co-design; 처리량 TBD
 - 트랙 placeholder 인덱스: {doc}`v003/index`
 

--- a/ko/docs/v003/index.md
+++ b/ko/docs/v003/index.md
@@ -7,14 +7,16 @@ v003 라인은 {doc}`v002 라인 <../v002/index>` 의 **LLM 트랙**을
 
 ## 작업 상태
 
-- 임시 계획 라인 저장소: [`pccx-LLM-v003`](https://github.com/pccxai/pccx-LLM-v003) (정본은 [`pccx-v003`](https://github.com/pccxai/pccx-v003))
-- 작업 staging 저장소: `pccx-LLM-v003-staging` (private)
-- 저장소는 evidence-tracked 상태로 생성됨; 안정된 릴리스 브랜치는
-  아직 없음
+- 정본 v003 IP-core 계획 패키지: [`pccx-v003`](https://github.com/pccxai/pccx-v003)
+  (planning / evidence-gated; 안정된 릴리스 브랜치는 아직 없음)
+- 이전 feeder [`pccx-LLM-v003`](https://github.com/pccxai/pccx-LLM-v003)
+  는 superseded / retired 상태이며 더 이상 활성 공개 트랙이 아니다.
+  재사용 가능한 v003 LLM 자료는 `pccx-v003/LLM/` 아래로 들어온다
 - v002 와 substrate 공유 — 동일한 KV260 보드, 동일한 W4A8
   weight × activation 비율, 동일한 L2 URAM 구성
-- 첫 모델 집중 — **Gemma 4 E4B** 를 파운데이션으로 두고, 릴리스
-  포인트마다 (v003.0, v003.1) 아키텍처 novelty 한 가지씩 적층
+- 첫 모델 집중 — **Gemma 4 E4B** 를 파운데이션으로 두는 계획
+  (planning), 릴리스 포인트마다 (v003.0, v003.1) 아키텍처 novelty
+  한 가지씩 적층
 - v002.x 의 단계 (sparsity, speculative, EAGLE, SSD, Tree,
   benchmark) 는 여기서 *반복하지 않음*; v003 는 다른 RTL
   베이스라인에서 시작한다

--- a/ko/index.rst
+++ b/ko/index.rst
@@ -65,10 +65,12 @@ pccx는 엣지 디바이스에서 Transformer 기반 LLM을 가속하기 위한
 
 공개 `pccxai/pccx-v003 <https://github.com/pccxai/pccx-v003>`_ 저장소는
 현재 v003 IP-core planning package 역할을 합니다. 이는 evidence-gated
-planning package이며, stable RTL release가 아닙니다. 임시
-`pccxai/pccx-LLM-v003 <https://github.com/pccxai/pccx-LLM-v003>`_ 라인은
-v003 LLM planning track을 공급하고, 보드/모델 저장소는 명시적인
-compatibility contract를 통해서만 v003 산출물을 소비합니다.
+planning package이며, stable RTL release가 아닙니다. 이전 feeder
+`pccxai/pccx-LLM-v003 <https://github.com/pccxai/pccx-LLM-v003>`_ 은
+superseded / retired 상태이며 더 이상 활성 공개 트랙이 아닙니다.
+재사용 가능한 v003 LLM 자료는 ``pccx-v003/LLM/`` 아래로 들어옵니다.
+보드/모델 저장소는 명시적인 compatibility contract 를 통해서만 v003
+산출물을 소비합니다.
 
 도구 & 랩
 ---------


### PR DESCRIPTION
Reflects the current public state across EN + KO docs:

- pccxai/pccx-v003 is the canonical v003 IP-core planning package (planning, evidence-gated).
- pccxai/pccx-LLM-v003 is superseded / retired and is no longer an active public track.

Touched: docs/v003/{overview,repository-boundary,compatibility-contract,open-questions}.md, docs/reference/repo-topology.md, docs/roadmap.md, docs/roadmap/milestones.md, index.rst, ko/index.rst, ko/docs/roadmap.md, ko/docs/v003/index.md, _static/diagrams/pccx_family_tree.svg.

Local sphinx-build / sphinx-lint are not installed in this clone; relying on CI to enforce strict and lint.

No timing, bitstream, board-runtime, model-execution, throughput, FPS, mAP, production-readiness, or trademark-registration claim is made here.