### PR TITLE
Rename pccx-llm-launcher references to pccx-launcher

### DIFF
--- a/docs/v002/Drivers/index.rst
+++ b/docs/v002/Drivers/index.rst
@@ -28,7 +28,7 @@ comment updates for the pccx v002 ISA reference URL.
    :class: note
 
    Driver bring-up is being mirrored at the launcher boundary by
-   ``pccx-llm-launcher``. The launcher's chat surface gates inputs and
+   ``pccx-launcher``. The launcher's chat surface gates inputs and
    outputs through a documented set of boundaries — chat status
    summary, evidence manifest, gap matrix, review packet, redaction
    policy, clipboard policy, accessibility, and empty-state — none of

--- a/ko/docs/v002/Drivers/index.rst
+++ b/ko/docs/v002/Drivers/index.rst
@@ -26,7 +26,7 @@ ISA 참조 URL 만 pccx v002 기준으로 갱신.
 .. admonition:: local LLM launcher — 상태 표면 boundary
    :class: note
 
-   드라이버 bring-up 은 ``pccx-llm-launcher`` 측 boundary 에서
+   드라이버 bring-up 은 ``pccx-launcher`` 측 boundary 에서
    미러된다. launcher 의 chat 표면은 입력 / 출력을 문서화된 boundary
    집합 — chat status summary, evidence manifest, gap matrix, review
    packet, redaction policy, clipboard policy, 접근성, empty-state —


### PR DESCRIPTION
## Summary
- Update docs references from pccx-llm-launcher to pccx-launcher.

## Validation
- `git diff --check`
- `rg` scan for old launcher identifiers