### PR TITLE
docs: drop obsolete vision-v001 staging references

### DIFF
--- a/docs/vision-v001/index.md
+++ b/docs/vision-v001/index.md
@@ -10,7 +10,6 @@ upstream RTL repository stabilises.
 ## Working state
 
 - repository: [`pccxai/pccx-vision-v001`](https://github.com/pccxai/pccx-vision-v001)
-- working staging repository: `pccx-vision-v001-staging` (private)
 - shared substrate with v002 — same KV260 board, same W4A8 weight ×
   activation ratio, same L2 URAM organisation
 - distinct dataflow — dense-conv tile reuse instead of token-by-token

--- a/ko/docs/vision-v001/index.md
+++ b/ko/docs/vision-v001/index.md
@@ -10,7 +10,6 @@ placeholder 다.
 ## 작업 상태
 
 - 저장소: [`pccxai/pccx-vision-v001`](https://github.com/pccxai/pccx-vision-v001)
-- 작업 staging 저장소: `pccx-vision-v001-staging` (private)
 - v002 와 substrate 공유 — 동일한 KV260 보드, 동일한 W4A8
   weight × activation 비율, 동일한 L2 URAM 구성
 - 데이터플로우는 다름 — 토큰 단위 KV 스트리밍이 아니라 dense


### PR DESCRIPTION
## Summary
- remove obsolete private staging repository bullets from the English and Korean vision-v001 docs
- leave the canonical public repository link intact

## Validation
- `rg -n "pccx-vision-v001-staging" docs/vision-v001 ko/docs/vision-v001` (no matches)