### PR TITLE
Tighten public documentation wording

### DIFF
--- a/docs/v002/ISA/index.rst
+++ b/docs/v002/ISA/index.rst
@@ -24,7 +24,7 @@ three principles:
 .. admonition:: Download the offline guidebook (PDF)
    :class: tip
 
-   A signoff-ready typeset version of this ISA reference — same tables,
+   A typeset v002 preprint version of this ISA reference — same tables,
    same numbers, offline-readable — is downloadable as a PDF:
 
    :download:`pccx v002 ISA Guidebook (PDF) <../../../_static/downloads/pccx-isa-v002.pdf>`

--- a/ko/docs/v002/ISA/index.rst
+++ b/ko/docs/v002/ISA/index.rst
@@ -20,8 +20,8 @@ pccx v002의 ISA는 **고정 길이 64-bit VLIW 스타일**\ 이며, 5개의 오
 .. admonition:: 오프라인 가이드북 (PDF) 다운로드
    :class: tip
 
-   동일한 표·동일한 값으로 조판된 오프라인 가이드북이 PDF로 제공된다.
-   HTML 포털과 달리 인쇄·아카이브·사인오프용 용도로 적합하다.
+   동일한 표·동일한 값으로 조판된 v002 preprint 오프라인 가이드북이
+   PDF로 제공된다. HTML 포털과 달리 인쇄·아카이브 용도로 적합하다.
 
    :download:`pccx v002 ISA 가이드북 (PDF) <../../../../_static/downloads/pccx-isa-v002.pdf>`
 

--- a/main.tex
+++ b/main.tex
@@ -1,7 +1,7 @@
 % =================================================================
 %  pccx v002 Instruction Set Architecture — Software Developer's Manual
 %
-%  Authoring entry point for the offline, signoff-ready PDF mirror of
+%  Authoring entry point for the offline preprint PDF mirror of
 %  the v002 ISA.  Styled after classical CPU software developer's
 %  manuals (per-instruction reference blocks, bit-level layouts,
 %  Operation pseudocode, Flags / Exceptions) and classical GPU
@@ -442,7 +442,7 @@ driver surface.
 The pccx web portal at \url{https://pccx.pages.dev/}
 contains a living, cross-referenced copy of the encoding tables
 together with interactive Mermaid, WaveDrom, and Graphviz diagrams.
-This PDF is the \textit{offline, signoff-ready} mirror; both sources
+This PDF is the \textit{offline preprint} mirror; both sources
 are rebuilt from the authoritative RTL definitions in the external
 repository
 \href{https://github.com/pccxai/pccx-FPGA-NPU-LLM-kv260}{\texttt{pccxai/pccx-FPGA-NPU-LLM-kv260}}
@@ -1227,7 +1227,7 @@ GEMM array.
 \caption{Per-core GEMV reduction tree (one of four cores shown).
 Stage 1 absorbs 32 partial products into 16 sums using DSP48E2 $A+B$
 adders; stages 2--5 use 6-LUT adders.  Each stage carries a pipeline
-register so the tree closes timing at 400\,MHz.}
+register to support the 400\,MHz timing target.}
 \label{fig:gemv-tree}
 \end{figure}
 


### PR DESCRIPTION
## Summary
- Replace ISA PDF "signoff-ready" wording with v002 preprint wording.
- Rephrase the GEMV reduction-tree timing sentence as a 400 MHz target.

## Deployment note
- Current deployed link `https://pccx.ai/_static/downloads/pccx-isa-v002.pdf` returns HTTP 200 with `Content-Type: text/html; charset=utf-8`, not `application/pdf`.

## Validation
- `git diff --check`
- Public wording scan over changed files
- `curl -I -L --max-time 20 https://pccx.ai/_static/downloads/pccx-isa-v002.pdf`

PDF rebuild was intentionally not run; update `_static/downloads/pccx-isa-v002.pdf` with `bash tools/build_isa_pdf.sh` after source review if a refreshed artifact is needed.
