### PR TITLE
docs: add crawler policy and root sitemap discovery

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,6 +71,9 @@ jobs:
         run: |
           mkdir -p _build/html
           touch _build/html/.nojekyll
+          if [ -f _extra/robots.txt ]; then
+            cp _extra/robots.txt _build/html/robots.txt
+          fi
           cat > _build/html/index.html << 'EOF'
           <!DOCTYPE html>
           <html lang="en">
@@ -101,6 +104,17 @@ jobs:
           cp _build/html/en/_static/pccx_wordmark_favicon.ico _build/html/favicon.ico
           cp _build/html/en/_static/pccx_wordmark_favicon.png _build/html/pccx_wordmark_favicon.png
           cp _build/html/en/_static/pccx_wordmark_favicon.svg _build/html/pccx_wordmark_favicon.svg
+          {
+            printf '%s\n' '<?xml version="1.0" encoding="UTF-8"?>'
+            printf '%s\n' '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+            if [ -f _build/html/en/sitemap-en.xml ]; then
+              printf '%s\n' '  <sitemap><loc>https://docs.pccx.ai/en/sitemap-en.xml</loc></sitemap>'
+            fi
+            if [ -f _build/html/ko/sitemap-ko.xml ]; then
+              printf '%s\n' '  <sitemap><loc>https://docs.pccx.ai/ko/sitemap-ko.xml</loc></sitemap>'
+            fi
+            printf '%s\n' '</sitemapindex>'
+          } > _build/html/sitemap.xml
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,9 @@ KO_SRC         := ko
 BUILD_ROOT     := _build/html
 EN_OUT         := $(BUILD_ROOT)/en
 KO_OUT         := $(BUILD_ROOT)/ko
+ROOT_ROBOTS    := _extra/robots.txt
+ROOT_SITEMAP   := $(BUILD_ROOT)/sitemap.xml
+PUBLIC_BASE_URL := https://docs.pccx.ai
 
 # Dev server ports.
 DEV_PORT_EN    := 8000
@@ -30,7 +33,7 @@ AUTOBLD_FLAGS  := --re-ignore '_build' --re-ignore 'auto_plots' --open-browser
 
 # -- Phony ------------------------------------------------------------------
 
-.PHONY: help en ko all strict dev-en dev-ko linkcheck lint clean distclean \
+.PHONY: help en ko all site-root-files strict dev-en dev-ko linkcheck lint clean distclean \
         check-codes install install-dev
 
 help:
@@ -73,7 +76,24 @@ en: check-codes
 ko: check-codes
 	$(SPHINXBUILD) -b html $(SPHINXOPTS) $(KO_SRC) $(KO_OUT)
 
-all: en ko
+all: en ko site-root-files
+
+site-root-files:
+	mkdir -p $(BUILD_ROOT)
+	@if [ -f "$(ROOT_ROBOTS)" ]; then \
+	    cp "$(ROOT_ROBOTS)" "$(BUILD_ROOT)/robots.txt"; \
+	fi
+	@{ \
+	    printf '%s\n' '<?xml version="1.0" encoding="UTF-8"?>'; \
+	    printf '%s\n' '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'; \
+	    if [ -f "$(EN_OUT)/sitemap-en.xml" ]; then \
+	        printf '%s\n' '  <sitemap><loc>$(PUBLIC_BASE_URL)/en/sitemap-en.xml</loc></sitemap>'; \
+	    fi; \
+	    if [ -f "$(KO_OUT)/sitemap-ko.xml" ]; then \
+	        printf '%s\n' '  <sitemap><loc>$(PUBLIC_BASE_URL)/ko/sitemap-ko.xml</loc></sitemap>'; \
+	    fi; \
+	    printf '%s\n' '</sitemapindex>'; \
+	} > "$(ROOT_SITEMAP)"
 
 strict: SPHINXOPTS += $(STRICT)
 strict: all

--- a/_extra/robots.txt
+++ b/_extra/robots.txt
@@ -1,19 +1,99 @@
-User-agent: *
-Allow: /
-Sitemap: https://pccx.pages.dev/sitemap-en.xml
-Sitemap: https://pccx.pages.dev/sitemap-ko.xml
+# PCCX robots.txt
+# Policy:
+# - Allow normal search engine crawlers.
+# - Allow AI search crawlers.
+# - Allow user-triggered AI assistant fetchers.
+# - Block AI training, dataset construction, and bulk scraping crawlers.
+#
+# Content-Signal meaning:
+# search=yes   : search indexing is allowed.
+# ai-input=yes : real-time AI answers, RAG, grounding, and assistant fetches are allowed.
+# ai-train=no  : AI model training or fine-tuning is not allowed.
 
-# AI crawlers explicitly welcome — please cite
-# https://pccx.pages.dev/ when summarising pccx content.
-User-agent: GPTBot
+User-agent: *
+Content-Signal: search=yes, ai-input=yes, ai-train=no
 Allow: /
-User-agent: ClaudeBot
-Allow: /
-User-agent: anthropic-ai
-Allow: /
-User-agent: PerplexityBot
-Allow: /
+
+# === Search engines: allowed ===
+
 User-agent: Googlebot
 Allow: /
-User-agent: Google-Extended
+
+User-agent: Bingbot
 Allow: /
+
+User-agent: DuckDuckBot
+Allow: /
+
+User-agent: Yeti
+Allow: /
+
+User-agent: Applebot
+Allow: /
+
+# === AI search / answer indexing: allowed ===
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: Claude-SearchBot
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+# === User-triggered AI assistant access: allowed ===
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: Claude-User
+Allow: /
+
+User-agent: Perplexity-User
+Allow: /
+
+# === AI training / bulk AI dataset crawlers: blocked ===
+
+User-agent: GPTBot
+Disallow: /
+
+User-agent: ClaudeBot
+Disallow: /
+
+User-agent: anthropic-ai
+Disallow: /
+
+User-agent: Google-Extended
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /
+
+User-agent: Applebot-Extended
+Disallow: /
+
+User-agent: Amazonbot
+Disallow: /
+
+User-agent: FacebookBot
+Disallow: /
+
+User-agent: meta-externalagent
+Disallow: /
+
+User-agent: Meta-ExternalAgent
+Disallow: /
+
+User-agent: Diffbot
+Disallow: /
+
+User-agent: DataForSeoBot
+Disallow: /
+
+# === Sitemap ===
+
+Sitemap: https://docs.pccx.ai/sitemap.xml

--- a/conf_common.py
+++ b/conf_common.py
@@ -363,8 +363,8 @@ html_theme_options = {
 templates_path = ["_templates"]
 html_static_path = ["_static"]     # KO conf overrides to ["../_static"]
 
-# ``_extra`` lives next to _static but is copied to the site root untouched
-# so llms.txt / robots.txt are served as /pccx/llms.txt, /pccx/robots.txt.
+# ``_extra`` lives next to _static and is copied to each language output root.
+# Deploy/build glue also copies robots.txt to the published site root.
 # (KO conf overrides the path prefix to ``../_extra``.)
 html_extra_path = ["_extra"]
 
@@ -454,7 +454,7 @@ intersphinx_timeout = 10
 # SEO / social
 # =============================================================================
 
-html_baseurl = "https://pccx.pages.dev/"
+html_baseurl = "https://docs.pccx.ai/"
 sitemap_url_scheme = "{link}"
 # sitemap_filename is overridden per-language in concrete conf.py.
 


### PR DESCRIPTION
## Summary
- add docs.pccx.ai robots.txt crawler policy
- publish root robots.txt and sitemap.xml from the docs build
- point root sitemap.xml at the generated language sitemaps

## Validation
- git diff --check
- make all SPHINXOPTS=
- test -f _build/html/robots.txt
- test -f _build/html/sitemap.xml
- XML parse check for _build/html/sitemap.xml
- wrong/private URL scan for localhost, pages.dev, /home, file://
- robots policy scan for required allow/disallow blocks