### PR TITLE
docs: add sidebar version selector

### DIFF
--- a/_static/custom.css
+++ b/_static/custom.css
@@ -247,6 +247,56 @@ article .pccx-lab-card .sd-card-title svg {
   vertical-align: -0.15em;
 }
 
+.pccx-version-switcher-item {
+  margin: 0.35rem 0 0.75rem;
+  list-style: none;
+}
+
+.pccx-version-switcher {
+  padding: 0.55rem 0.65rem;
+  border: 1px solid var(--color-background-border);
+  border-radius: 6px;
+  background: var(--color-background-secondary);
+}
+
+.pccx-version-switcher__label {
+  margin-bottom: 0.35rem;
+  font-size: 0.68rem;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--color-foreground-muted);
+  text-transform: uppercase;
+}
+
+.pccx-version-switcher__list {
+  display: grid;
+  gap: 0.12rem;
+}
+
+.pccx-version-switcher__entry {
+  display: block;
+  padding: 0.24rem 0;
+  font-size: 0.82rem;
+  line-height: 1.25;
+  color: var(--color-foreground-secondary);
+  text-decoration: none !important;
+}
+
+.pccx-version-switcher__entry:hover,
+.pccx-version-switcher__entry:focus-visible {
+  color: var(--color-brand-primary);
+}
+
+.pccx-version-switcher__entry.is-active {
+  font-weight: 700;
+  color: var(--color-foreground-primary);
+}
+
+.pccx-version-switcher__entry.is-disabled {
+  color: var(--color-foreground-muted);
+  cursor: default;
+}
+
 /* -- rtl_source admonition (injected by _ext/rtl_source.py) ---------------- */
 article .admonition.pccx-rtl-source {
   border-inline-start-width: 3px;

--- a/_static/pccx-version-switcher.js
+++ b/_static/pccx-version-switcher.js
@@ -1,0 +1,141 @@
+(function () {
+  "use strict";
+
+  const ACTIVE_STATUSES = new Set(["current", "available", "archived"]);
+
+  function currentScriptBase() {
+    const script = document.currentScript;
+    if (script && script.src) {
+      return new URL(".", script.src);
+    }
+    const fallback = document.querySelector('script[src$="pccx-version-switcher.js"]');
+    if (fallback && fallback.src) {
+      return new URL(".", fallback.src);
+    }
+    return new URL("_static/", window.location.href);
+  }
+
+  function pageLanguage() {
+    const lang = document.documentElement.getAttribute("lang") || "";
+    if (lang.toLowerCase().startsWith("ko")) {
+      return "ko";
+    }
+    const parts = window.location.pathname.split("/").filter(Boolean);
+    if (parts[0] === "ko") {
+      return "ko";
+    }
+    return "en";
+  }
+
+  function entryUrl(entry, lang) {
+    if (entry.urls && typeof entry.urls === "object" && entry.urls[lang]) {
+      return entry.urls[lang];
+    }
+    return entry.url || "";
+  }
+
+  function normalizePath(url) {
+    try {
+      const parsed = new URL(url, window.location.origin);
+      let pathname = parsed.pathname || "/";
+      if (!pathname.endsWith("/")) {
+        pathname += "/";
+      }
+      return pathname;
+    } catch (_error) {
+      return "";
+    }
+  }
+
+  function activeSlug(entries, lang) {
+    const currentPath = normalizePath(window.location.pathname);
+    const specific = entries.find((entry) => {
+      if (entry.slug === "current") {
+        return false;
+      }
+      const target = normalizePath(entryUrl(entry, lang));
+      return target && (currentPath === target || currentPath.startsWith(target));
+    });
+    return specific ? specific.slug : "current";
+  }
+
+  function buildEntry(entry, lang, active) {
+    const url = entryUrl(entry, lang);
+    const clickable = url && ACTIVE_STATUSES.has(entry.status);
+    const node = document.createElement(clickable ? "a" : "span");
+    node.className = "pccx-version-switcher__entry";
+    node.dataset.pccxVersion = entry.slug || entry.label || "";
+    node.dataset.pccxVersionStatus = entry.status || "";
+    node.textContent = entry.label || entry.slug || "Version";
+    if (entry.slug === active) {
+      node.classList.add("is-active");
+      node.setAttribute("aria-current", "page");
+    }
+    if (clickable) {
+      node.href = url;
+      node.dataset.pccxVersionUrl = url;
+    } else {
+      node.classList.add("is-disabled");
+      node.setAttribute("aria-disabled", "true");
+    }
+    return node;
+  }
+
+  function placeSwitcher(switcher) {
+    const tree = document.querySelector(".sidebar-tree");
+    if (!tree) {
+      switcher.hidden = false;
+      return;
+    }
+    const list = tree.querySelector(":scope > ul") || tree.querySelector("ul");
+    const firstItem = list ? list.querySelector(":scope > li") || list.querySelector("li") : null;
+    const wrapper = document.createElement("li");
+    wrapper.className = "toctree-l1 pccx-version-switcher-item";
+    wrapper.appendChild(switcher);
+    if (firstItem && firstItem.parentNode) {
+      firstItem.insertAdjacentElement("afterend", wrapper);
+    } else if (list) {
+      list.insertBefore(wrapper, list.firstChild);
+    } else {
+      tree.insertBefore(wrapper, tree.firstChild);
+    }
+    switcher.hidden = false;
+  }
+
+  function render(entries) {
+    const switcher = document.querySelector("[data-pccx-version-switcher]");
+    if (!switcher || !Array.isArray(entries) || entries.length === 0) {
+      return;
+    }
+    const lang = pageLanguage();
+    const active = activeSlug(entries, lang);
+    const list = switcher.querySelector("[data-pccx-version-list]");
+    if (!list) {
+      return;
+    }
+    list.replaceChildren();
+    for (const entry of entries) {
+      if (!entry || !entry.label) {
+        continue;
+      }
+      list.appendChild(buildEntry(entry, lang, active));
+    }
+    placeSwitcher(switcher);
+  }
+
+  async function main() {
+    const base = currentScriptBase();
+    const manifestUrl = new URL("pccx_versions.json", base);
+    const response = await fetch(manifestUrl, { cache: "no-cache" });
+    if (!response.ok) {
+      throw new Error("version manifest unavailable");
+    }
+    render(await response.json());
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", main, { once: true });
+  } else {
+    main();
+  }
+})();

--- a/_static/pccx_versions.json
+++ b/_static/pccx_versions.json
@@ -1,0 +1,42 @@
+[
+  {
+    "label": "Current",
+    "slug": "current",
+    "url": "/",
+    "urls": {
+      "en": "/en/",
+      "ko": "/ko/"
+    },
+    "status": "current"
+  },
+  {
+    "label": "v003",
+    "slug": "v003",
+    "url": "/en/docs/v003/",
+    "urls": {
+      "en": "/en/docs/v003/",
+      "ko": "/ko/docs/v003/"
+    },
+    "status": "available"
+  },
+  {
+    "label": "v002",
+    "slug": "v002",
+    "url": "/en/docs/v002/",
+    "urls": {
+      "en": "/en/docs/v002/",
+      "ko": "/ko/docs/v002/"
+    },
+    "status": "available"
+  },
+  {
+    "label": "v001",
+    "slug": "v001",
+    "url": "/en/docs/archive/experimental_v001/",
+    "urls": {
+      "en": "/en/docs/archive/experimental_v001/",
+      "ko": "/ko/docs/archive/experimental_v001/"
+    },
+    "status": "archived"
+  }
+]

--- a/_templates/sidebar/navigation.html
+++ b/_templates/sidebar/navigation.html
@@ -1,0 +1,11 @@
+<div class="sidebar-tree">
+  {{ furo_navigation_tree }}
+  <div class="pccx-version-switcher"
+       data-pccx-version-switcher
+       hidden>
+    <div class="pccx-version-switcher__label">PCCX version</div>
+    <div class="pccx-version-switcher__list" data-pccx-version-list>
+      <a class="pccx-version-switcher__entry is-active" href="/">Current</a>
+    </div>
+  </div>
+</div>

--- a/conf_common.py
+++ b/conf_common.py
@@ -379,6 +379,7 @@ html_css_files = [
 html_js_files = [
     "image-lightbox.js",
     "language-switcher.js",
+    "pccx-version-switcher.js",
     "auto-translate-dismiss.js",
 ]
 


### PR DESCRIPTION
## Summary
- add a manifest-driven Furo sidebar version selector
- keep the existing introduction entry above the selector
- expose current, v003, v002, and v001 links only where built targets exist

## Validation
- git diff --check
- node --check _static/pccx-version-switcher.js
- JSON parse for _static/pccx_versions.json
- make all SPHINXOPTS=
- built selector marker, Introduction/Overview, robots.txt, sitemap.xml, crawler-policy, and version-target checks

Note: clean origin/main still emits pre-existing pccx.pages.dev references in generated metadata/llms output; this PR does not introduce those references.