### PR TITLE
feat: redirect PCCX docs to Altifigence docs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,6 +74,9 @@ jobs:
           if [ -f _extra/robots.txt ]; then
             cp _extra/robots.txt _build/html/robots.txt
           fi
+          if [ -f _extra/_redirects ]; then
+            cp _extra/_redirects _build/html/_redirects
+          fi
           cat > _build/html/index.html << 'EOF'
           <!DOCTYPE html>
           <html lang="en">

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,9 @@ site-root-files:
 	@if [ -f "$(ROOT_ROBOTS)" ]; then \
 	    cp "$(ROOT_ROBOTS)" "$(BUILD_ROOT)/robots.txt"; \
 	fi
+	@if [ -f "_extra/_redirects" ]; then \
+	    cp "_extra/_redirects" "$(BUILD_ROOT)/_redirects"; \
+	fi
 	@{ \
 	    printf '%s\n' '<?xml version="1.0" encoding="UTF-8"?>'; \
 	    printf '%s\n' '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'; \

--- a/_extra/_redirects
+++ b/_extra/_redirects
@@ -1,0 +1,9 @@
+/en/docs/v002/* https://docs.altifigence.com/products/v002/:splat 301
+/ko/docs/v002/* https://docs.altifigence.com/kr-ko/products/v002/:splat 301
+/docs/v002/* https://docs.altifigence.com/products/v002/:splat 301
+/en/* https://docs.altifigence.com/v002/sphinx-mirror/:splat 301
+/ko/* https://docs.altifigence.com/v002/sphinx-mirror/ko/:splat 301
+/robots.txt https://docs.altifigence.com/robots.txt 301
+/sitemap.xml https://docs.altifigence.com/sitemap.xml 301
+/ https://docs.altifigence.com/v002/sphinx-mirror/ 301
+/* https://docs.altifigence.com/v002/sphinx-mirror/:splat 301

--- a/conf_common.py
+++ b/conf_common.py
@@ -429,6 +429,10 @@ def _write_cloudflare_root_discovery_files(app, exception) -> None:
     if robots_src.exists():
         shutil.copyfile(robots_src, build_root / "robots.txt")
 
+    redirects_src = Path(_CONF_COMMON_DIR) / "_extra" / "_redirects"
+    if redirects_src.exists():
+        shutil.copyfile(redirects_src, build_root / "_redirects")
+
     sitemap_entries = [
         ("en", "sitemap-en.xml"),
         ("ko", "sitemap-ko.xml"),


### PR DESCRIPTION
## Summary
- add Cloudflare Pages _redirects for docs.pccx.ai to docs.altifigence.com target paths
- copy the redirect file into the Sphinx build root from local Makefile and GitHub Pages workflow
- keep v002 routes mapped to /products/v002 or /kr-ko/products/v002 and all other docs routes mapped to /v002/sphinx-mirror

## Verification
- PATH=.venv/bin:$PATH make all
- PATH=.venv/bin:$PATH make strict
- Cloudflare Pages redirect preview: https://feat-pccx-ai-100-migration-r.pccx.pages.dev
- representative preview curl checks returned 301 to docs.altifigence.com

## Review gate
- Do not merge until code-reviewer approval is complete.
- Do not push this directly to main.