### PR TITLE
Cut cross-domain _redirects so docs.pccx.ai stays standalone

### DIFF
--- a/_extra/_redirects
+++ b/_extra/_redirects
@@ -1,9 +1,0 @@
-/en/docs/v002/* https://docs.altifigence.com/products/v002/:splat 301
-/ko/docs/v002/* https://docs.altifigence.com/kr-ko/products/v002/:splat 301
-/docs/v002/* https://docs.altifigence.com/products/v002/:splat 301
-/en/* https://docs.altifigence.com/v002/sphinx-mirror/:splat 301
-/ko/* https://docs.altifigence.com/v002/sphinx-mirror/ko/:splat 301
-/robots.txt https://docs.altifigence.com/robots.txt 301
-/sitemap.xml https://docs.altifigence.com/sitemap.xml 301
-/ https://docs.altifigence.com/v002/sphinx-mirror/ 301
-/* https://docs.altifigence.com/v002/sphinx-mirror/:splat 301


### PR DESCRIPTION
## Summary

- Delete `_extra/_redirects`. It held nine 301 rules that rewrote every docs.pccx.ai page (`/`, `/*`, `/en/*`, `/ko/*`, `/docs/v002/*`, `/en/docs/v002/*`, `/ko/docs/v002/*`, `/robots.txt`, `/sitemap.xml`) to corresponding paths under `docs.altifigence.com`. With those rules removed, docs.pccx.ai serves its own Sphinx build directly.

## Why

`docs.pccx.ai` is now the v002 legacy archive and is fully separated from `docs.altifigence.com` (the canonical PCCX hub beyond v002). Forwarding visitors to docs.altifigence.com fights that split, and the redirect cache it produces (301 is permanently cached by browsers) leaves users stuck at `account.altifigence.com` when they later try to reach `https://docs.pccx.ai`.

The deploy workflow already guards the redirect-copy step on `if [ -f _extra/_redirects ]; then cp ...; fi`, so removing the file makes the step a no-op without any other workflow change. The Sphinx build's existing root `index.html` (`<meta http-equiv="refresh" content="0; url=en/index.html">`) keeps the site fully self-contained.

## Related changes

- `pccxai/pccx-vision-v001` repo deleted 2026-05-27.
- `docs/{v003,vision-v001,Lab}` and ko mirrors removed from this Sphinx tree in #107.
- `Altifigence/altifigence-docs#93` landed the one-time Sphinx HTML snapshot at `docs.altifigence.com/v002/sphinx-mirror/`. The two sites do not sync going forward.

## Test plan

- [ ] `make strict` (CI) builds without warnings.
- [ ] After deploy, `curl -sI https://docs.pccx.ai/` returns `302` with `Location: /en/` (same domain).
- [ ] `curl -sI https://docs.pccx.ai/en/docs/v002/Architecture/rationale.html` returns 200 with Sphinx HTML.
- [ ] Browser visit to `https://docs.pccx.ai` in incognito (no stale 301 cache) lands on the v002 docs, not on `account.altifigence.com`.